### PR TITLE
WIP: implement migration

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,2 +1,3 @@
 pytest
 mock
+ipython

--- a/jupyter_core/migrate.py
+++ b/jupyter_core/migrate.py
@@ -64,6 +64,9 @@ config_substitutions = {
 
 def migrate_dir(src, dst):
     """Migrate a directory"""
+    if not os.listdir(src):
+        print("No files in %s" % src)
+        return False
     if os.path.exists(dst):
         if os.listdir(dst):
             # already exists, non-empty
@@ -111,6 +114,12 @@ def migrate_one(src, dst):
 
 
 def migrate_static_custom(src, dst):
+    """Migrate non-empty custom.js,css from src to dst
+    
+    src, dst are 'custom' directories containing custom.{js,css}
+    """
+    migrated = False
+    
     custom_js = pjoin(src, 'custom.js')
     custom_css = pjoin(src, 'custom.css')
     # check if custom_js is empty:
@@ -136,16 +145,20 @@ def migrate_static_custom(src, dst):
     
     if custom_js_empty and custom_css_empty:
         # nothing to migrate
-        return
+        return False
     ensure_dir_exists(dst)
     
     if not custom_js_empty or not custom_css_empty:
         ensure_dir_exists(dst)
     
     if not custom_js_empty:
-        migrate_file(custom_js, pjoin(dst, 'custom.js'))
+        if migrate_file(custom_js, pjoin(dst, 'custom.js')):
+            migrated = True
     if not custom_css_empty:
-        migrate_file(custom_css, pjoin(dst, 'custom.css'))
+        if migrate_file(custom_css, pjoin(dst, 'custom.css')):
+            migrated = True
+    
+    return migrated
 
 
 def migrate_config(name, env):

--- a/jupyter_core/migrate.py
+++ b/jupyter_core/migrate.py
@@ -172,7 +172,7 @@ def migrate():
         'jupyter_data': jupyter_data_dir(),
         'jupyter_config': jupyter_config_dir(),
         'ipython_dir': get_ipython_dir(),
-        'profile': locate_profile(),
+        'profile': os.path.join(get_ipython_dir(), 'profile_default'),
     }
     for src_t, dst_t in migrations.items():
         src = src_t.format(**env)

--- a/jupyter_core/migrate.py
+++ b/jupyter_core/migrate.py
@@ -91,7 +91,7 @@ def migrate_file(src, dst, substitutions=None):
         return False
     print("Copying %s -> %s" % (src, dst))
     ensure_dir_exists(os.path.dirname(dst))
-    shutil.copy(src, dst, follow_symlinks=False)
+    shutil.copy(src, dst)
     if substitutions:
         with open(dst) as f:
             text = f.read()

--- a/jupyter_core/migrate.py
+++ b/jupyter_core/migrate.py
@@ -154,16 +154,19 @@ def migrate_config(name, env):
         '.py': PyFileConfigLoader,
         '.json': JSONFileConfigLoader,
     }
+    migrated = []
     for ext in ('.py', '.json'):
         src = src_base + ext
         dst = dst_base + ext
         if os.path.exists(src):
             cfg = loaders[ext](src).load_config()
             if cfg:
-                migrate_file(src, dst, substitutions=config_substitutions)
+                if migrate_file(src, dst, substitutions=config_substitutions):
+                    migrated.append(src)
             else:
                 # don't migrate empty config files
                 print("Not migrating empty config file: %s" % src)
+    return migrated
 
 
 def migrate():

--- a/jupyter_core/migrate.py
+++ b/jupyter_core/migrate.py
@@ -1,0 +1,201 @@
+"""Migrating IPython < 4.0 to Jupyter
+
+This *copies* configuration and resources to their new locations in Jupyter
+
+Migrations:
+
+- .ipython/
+  - nbextensions -> JUPYTER_DATA_DIR/nbextensions
+  - kernels ->  JUPYTER_DATA_DIR/kernels
+- .ipython/profile_default/
+  - static/custom -> .jupyter/custom
+  - nbconfig -> .jupyter/nbconfig
+  - security/
+    - notebook_secret, notebook_cookie_secret, nbsignatures.db -> JUPYTER_DATA_DIR
+  - ipython_{notebook,nbconvert,qtconsole}_config.py -> .jupyter/jupyter_{name}_config.py
+
+
+"""
+
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+import os
+import re
+import shutil
+
+from traitlets.config import PyFileConfigLoader, JSONFileConfigLoader
+
+from ipython_genutils.path import ensure_dir_exists
+from IPython.paths import get_ipython_dir, locate_profile
+from .paths import jupyter_config_dir, jupyter_data_dir
+from .application import JupyterApp
+
+pjoin = os.path.join
+
+migrations = {
+    pjoin('{ipython_dir}', 'nbextensions'): pjoin('{jupyter_data}', 'nbextensions'),
+    pjoin('{ipython_dir}', 'kernels'): pjoin('{jupyter_data}', 'kernels'),
+    pjoin('{profile}', 'nbconfig'): pjoin('{jupyter_config}', 'nbconfig'),
+}
+
+custom_src_t = pjoin('{profile}', 'static', 'custom')
+custom_dst_t = pjoin('{jupyter_config}', 'custom'),
+
+for security_file in ('notebook_secret', 'notebook_cookie_secret', 'nbsignatures.db'):
+    src = pjoin('{profile}', 'security', security_file)
+    dst = pjoin('{jupyter_data}', security_file)
+    migrations[src] = dst
+
+config_migrations = ['notebook', 'nbconvert', 'qtconsole']
+
+
+def migrate_dir(src, dst):
+    """Migrate a directory"""
+    if os.path.exists(dst):
+        if os.listdir(dst):
+            # already exists, non-empty
+            print("%s already exists" % dst)
+            return False
+        else:
+            os.rmdir(dst)
+    print("Copying %s -> %s" % (src, dst))
+    ensure_dir_exists(os.path.dirname(dst))
+    shutil.copytree(src, dst, symlinks=True)
+    return True
+
+
+def migrate_file(src, dst):
+    """Migrate a single file"""
+    if os.path.exists(dst):
+        # already exists
+        print("%s already exists" % dst)
+        return False
+    print("Copying %s -> %s" % (src, dst))
+    ensure_dir_exists(os.path.dirname(dst))
+    shutil.copy(src, dst, follow_symlinks=False)
+    return True
+
+
+def migrate_one(src, dst):
+    """Migrate one item
+    
+    dispatches to migrate_dir/_file
+    """
+    if os.path.isfile(src):
+        return migrate_file(src, dst)
+    elif os.path.isdir(src):
+        return migrate_dir(src, dst)
+    else:
+        print("Nothing to migrate for %s" % src)
+        return False
+
+
+def migrate_static_custom(src, dst):
+    custom_js = pjoin(src, 'custom.js')
+    custom_css = pjoin(src, 'custom.css')
+    # check if custom_js is empty:
+    custom_js_empty = True
+    with open(custom_js) as f:
+        js = f.read().strip()
+        for line in js.splitlines():
+            if not (
+                line.isspace()
+                or line.strip().startswith(('/*', '*', '//'))
+            ):
+                custom_js_empty = False
+                break
+    
+    with open(custom_css) as f:
+        css = f.read().strip()
+        custom_css_empty = css.startswith('/*') and css.endswith('*/')
+    
+    if custom_js_empty:
+        print("Ignoring empty %s" % custom_js)
+    if custom_css_empty:
+        print("Ignoring empty %s" % custom_css)
+    
+    if custom_js_empty and custom_css_empty:
+        # nothing to migrate
+        return
+    ensure_dir_exists(dst)
+    
+    if not custom_js_empty or not custom_css_empty:
+        ensure_exists(dst)
+
+
+def migrate_config(name, env):
+    """Migrate a config file
+    
+    """
+    src_base = pjoin('{profile}', 'ipython_{name}_config').format(name=name, **env)
+    dst_base = pjoin('{jupyter_config}', 'jupyter_{name}_config').format(name=name, **env)
+    loaders = {
+        '.py': PyFileConfigLoader,
+        '.json': JSONFileConfigLoader,
+    }
+    for ext in ('.py', '.json'):
+        src = src_base + ext
+        dst = dst_base + ext
+        if os.path.exists(src):
+            cfg = loaders[ext](src).load_config()
+            if cfg:
+                migrate_file(src, dst)
+            else:
+                # don't migrate empty config files
+                print("Not migrating empty config file: %s" % src)
+
+
+def migrate():
+    """Perform migrations"""
+    env = {
+        'jupyter_data': jupyter_data_dir(),
+        'jupyter_config': jupyter_config_dir(),
+        'ipython_dir': get_ipython_dir(),
+        'profile': locate_profile(),
+    }
+    for src_t, dst_t in migrations.items():
+        src = src_t.format(**env)
+        dst = dst_t.format(**env)
+        if os.path.exists(src):
+            if migrate_one(src, dst):
+                pass
+    
+    for name in config_migrations:
+        migrate_config(name, env)
+    
+    custom_src = custom_src_t.format(**env)
+    custom_dst = custom_dst_t.format(**env)
+    
+    if os.path.exists(custom_src):
+        migrate_static_custom(custom_src, custom_dst)
+
+
+class MigrateApp(JupyterApp):
+    name = 'jupyter-migrate'
+    description = """
+    Migrate configuration and data from .ipython prior to 4.0 to Jupyter locations.
+    
+    This migrates:
+    
+    - config files in the default profile
+    - kernels in ~/.ipython/kernels
+    - notebook javascript extensions in ~/.ipython/extensions
+    - custom.js/css to .jupyter/custom
+    
+    to their new Jupyter locations.
+    
+    All files are copied, not moved.
+    If the destinations already exist, nothing will be done.
+    """
+    
+    def start(self):
+        migrate()
+
+
+main = MigrateApp.launch_instance
+
+
+if __name__ == '__main__':
+    main()
+

--- a/jupyter_core/migrate.py
+++ b/jupyter_core/migrate.py
@@ -58,8 +58,8 @@ regex = re.compile
 
 config_substitutions = {
     regex(r'\bIPythonQtConsoleApp\b'): 'JupyterQtConsoleApp',
-    regex(r'\bIPython\.html\b'): 'jupyter_notebook',
-    regex(r'\bIPython\.nbconvert\b'): 'jupyter_nbconvert',
+    regex(r'\bIPython\.html\b'): 'notebook',
+    regex(r'\bIPython\.nbconvert\b'): 'nbconvert',
 }
 
 def migrate_dir(src, dst):

--- a/jupyter_core/migrate.py
+++ b/jupyter_core/migrate.py
@@ -27,7 +27,12 @@ import shutil
 from traitlets.config import PyFileConfigLoader, JSONFileConfigLoader
 
 from ipython_genutils.path import ensure_dir_exists
-from IPython.paths import get_ipython_dir, locate_profile
+try:
+    from IPython.paths import get_ipython_dir, locate_profile
+except ImportError:
+    # IPython < 4
+    from IPython.utils.path import get_ipython_dir, locate_profile
+
 from .paths import jupyter_config_dir, jupyter_data_dir
 from .application import JupyterApp
 

--- a/jupyter_core/migrate.py
+++ b/jupyter_core/migrate.py
@@ -63,7 +63,7 @@ config_substitutions = {
 }
 
 def migrate_dir(src, dst):
-    """Migrate a directory"""
+    """Migrate a directory from src to dst"""
     if not os.listdir(src):
         print("No files in %s" % src)
         return False
@@ -81,7 +81,10 @@ def migrate_dir(src, dst):
 
 
 def migrate_file(src, dst, substitutions=None):
-    """Migrate a single file"""
+    """Migrate a single file from src to dst
+    
+    substitutions is an optional dict of {regex: replacement} for performing replacements on the file.
+    """
     if os.path.exists(dst):
         # already exists
         print("%s already exists" % dst)
@@ -188,7 +191,7 @@ def migrate_config(name, env):
 
 
 def migrate():
-    """Perform migrations"""
+    """Migrate IPython configuration to Jupyter"""
     env = {
         'jupyter_data': jupyter_data_dir(),
         'jupyter_config': jupyter_config_dir(),

--- a/jupyter_core/tests/dotipython/nbextensions/myext.js
+++ b/jupyter_core/tests/dotipython/nbextensions/myext.js
@@ -1,0 +1,1 @@
+var hello;

--- a/jupyter_core/tests/dotipython/profile_default/ipython_config.py
+++ b/jupyter_core/tests/dotipython/profile_default/ipython_config.py
@@ -1,0 +1,549 @@
+# Configuration file for ipython.
+
+c = get_config()
+
+#------------------------------------------------------------------------------
+# InteractiveShellApp configuration
+#------------------------------------------------------------------------------
+
+# A Mixin for applications that start InteractiveShell instances.
+# 
+# Provides configurables for loading extensions and executing files as part of
+# configuring a Shell environment.
+# 
+# The following methods should be called by the :meth:`initialize` method of the
+# subclass:
+# 
+#   - :meth:`init_path`
+#   - :meth:`init_shell` (to be implemented by the subclass)
+#   - :meth:`init_gui_pylab`
+#   - :meth:`init_extensions`
+#   - :meth:`init_code`
+
+# lines of code to run at IPython startup.
+# c.InteractiveShellApp.exec_lines = []
+
+# Should variables loaded at startup (by startup files, exec_lines, etc.) be
+# hidden from tools like %who?
+# c.InteractiveShellApp.hide_initial_ns = True
+
+# A list of dotted module names of IPython extensions to load.
+# c.InteractiveShellApp.extensions = []
+
+# Enable GUI event loop integration with any of ('glut', 'gtk', 'gtk3', 'osx',
+# 'pyglet', 'qt', 'qt5', 'tk', 'wx').
+# c.InteractiveShellApp.gui = None
+
+# A file to be run
+# c.InteractiveShellApp.file_to_run = ''
+
+# Configure matplotlib for interactive use with the default matplotlib backend.
+# c.InteractiveShellApp.matplotlib = None
+
+# Reraise exceptions encountered loading IPython extensions?
+# c.InteractiveShellApp.reraise_ipython_extension_failures = False
+
+# Run the file referenced by the PYTHONSTARTUP environment variable at IPython
+# startup.
+# c.InteractiveShellApp.exec_PYTHONSTARTUP = True
+
+# Pre-load matplotlib and numpy for interactive use, selecting a particular
+# matplotlib backend and loop integration.
+# c.InteractiveShellApp.pylab = None
+
+# Run the module as a script.
+# c.InteractiveShellApp.module_to_run = ''
+
+# dotted module name of an IPython extension to load.
+# c.InteractiveShellApp.extra_extension = ''
+
+# List of files to run at IPython startup.
+# c.InteractiveShellApp.exec_files = []
+
+# If true, IPython will populate the user namespace with numpy, pylab, etc. and
+# an ``import *`` is done from numpy and pylab, when using pylab mode.
+# 
+# When False, pylab mode should not import any names into the user namespace.
+# c.InteractiveShellApp.pylab_import_all = True
+
+# Execute the given command string.
+# c.InteractiveShellApp.code_to_run = ''
+
+#------------------------------------------------------------------------------
+# TerminalIPythonApp configuration
+#------------------------------------------------------------------------------
+
+# TerminalIPythonApp will inherit config from: BaseIPythonApplication,
+# Application, InteractiveShellApp
+
+# Should variables loaded at startup (by startup files, exec_lines, etc.) be
+# hidden from tools like %who?
+# c.TerminalIPythonApp.hide_initial_ns = True
+
+# A list of dotted module names of IPython extensions to load.
+# c.TerminalIPythonApp.extensions = []
+
+# Execute the given command string.
+# c.TerminalIPythonApp.code_to_run = ''
+
+# The date format used by logging formatters for %(asctime)s
+# c.TerminalIPythonApp.log_datefmt = '%Y-%m-%d %H:%M:%S'
+
+# Reraise exceptions encountered loading IPython extensions?
+# c.TerminalIPythonApp.reraise_ipython_extension_failures = False
+
+# Set the log level by value or name.
+# c.TerminalIPythonApp.log_level = 30
+
+# Run the file referenced by the PYTHONSTARTUP environment variable at IPython
+# startup.
+# c.TerminalIPythonApp.exec_PYTHONSTARTUP = True
+
+# Pre-load matplotlib and numpy for interactive use, selecting a particular
+# matplotlib backend and loop integration.
+# c.TerminalIPythonApp.pylab = None
+
+# Run the module as a script.
+# c.TerminalIPythonApp.module_to_run = ''
+
+# Whether to display a banner upon starting IPython.
+# c.TerminalIPythonApp.display_banner = True
+
+# dotted module name of an IPython extension to load.
+# c.TerminalIPythonApp.extra_extension = ''
+
+# Create a massive crash report when IPython encounters what may be an internal
+# error.  The default is to append a short message to the usual traceback
+# c.TerminalIPythonApp.verbose_crash = False
+
+# Whether to overwrite existing config files when copying
+# c.TerminalIPythonApp.overwrite = False
+
+# The IPython profile to use.
+# c.TerminalIPythonApp.profile = 'default'
+
+# If a command or file is given via the command-line, e.g. 'ipython foo.py',
+# start an interactive shell after executing the file or command.
+# c.TerminalIPythonApp.force_interact = False
+
+# List of files to run at IPython startup.
+# c.TerminalIPythonApp.exec_files = []
+
+# Start IPython quickly by skipping the loading of config files.
+# c.TerminalIPythonApp.quick = False
+
+# The Logging format template
+# c.TerminalIPythonApp.log_format = '[%(name)s]%(highlevel)s %(message)s'
+
+# Whether to install the default config files into the profile dir. If a new
+# profile is being created, and IPython contains config files for that profile,
+# then they will be staged into the new directory.  Otherwise, default config
+# files will be automatically generated.
+# c.TerminalIPythonApp.copy_config_files = False
+
+# Path to an extra config file to load.
+# 
+# If specified, load this config file in addition to any other IPython config.
+# c.TerminalIPythonApp.extra_config_file = ''
+
+# lines of code to run at IPython startup.
+# c.TerminalIPythonApp.exec_lines = []
+
+# Enable GUI event loop integration with any of ('glut', 'gtk', 'gtk3', 'osx',
+# 'pyglet', 'qt', 'qt5', 'tk', 'wx').
+# c.TerminalIPythonApp.gui = None
+
+# A file to be run
+# c.TerminalIPythonApp.file_to_run = ''
+
+# Configure matplotlib for interactive use with the default matplotlib backend.
+# c.TerminalIPythonApp.matplotlib = None
+
+# Suppress warning messages about legacy config files
+# c.TerminalIPythonApp.ignore_old_config = False
+
+# The name of the IPython directory. This directory is used for logging
+# configuration (through profiles), history storage, etc. The default is usually
+# $HOME/.ipython. This option can also be specified through the environment
+# variable IPYTHONDIR.
+# c.TerminalIPythonApp.ipython_dir = ''
+
+# If true, IPython will populate the user namespace with numpy, pylab, etc. and
+# an ``import *`` is done from numpy and pylab, when using pylab mode.
+# 
+# When False, pylab mode should not import any names into the user namespace.
+# c.TerminalIPythonApp.pylab_import_all = True
+
+#------------------------------------------------------------------------------
+# TerminalInteractiveShell configuration
+#------------------------------------------------------------------------------
+
+# TerminalInteractiveShell will inherit config from: InteractiveShell
+
+# 
+# c.TerminalInteractiveShell.object_info_string_level = 0
+
+# 
+# c.TerminalInteractiveShell.separate_out = ''
+
+# Automatically call the pdb debugger after every exception.
+# c.TerminalInteractiveShell.pdb = False
+
+# 
+# c.TerminalInteractiveShell.ipython_dir = ''
+
+# 
+# c.TerminalInteractiveShell.history_length = 10000
+
+# 
+# c.TerminalInteractiveShell.readline_remove_delims = '-/~'
+
+# auto editing of files with syntax errors.
+# c.TerminalInteractiveShell.autoedit_syntax = False
+
+# If True, anything that would be passed to the pager will be displayed as
+# regular output instead.
+# c.TerminalInteractiveShell.display_page = False
+
+# 
+# c.TerminalInteractiveShell.debug = False
+
+# 
+# c.TerminalInteractiveShell.separate_in = '\n'
+
+# Start logging to the default log file in overwrite mode. Use `logappend` to
+# specify a log file to **append** logs to.
+# c.TerminalInteractiveShell.logstart = False
+
+# Set the size of the output cache.  The default is 1000, you can change it
+# permanently in your config file.  Setting it to 0 completely disables the
+# caching system, and the minimum value accepted is 20 (if you provide a value
+# less than 20, it is reset to 0 and a warning is issued).  This limit is
+# defined because otherwise you'll spend more time re-flushing a too small cache
+# than working
+# c.TerminalInteractiveShell.cache_size = 1000
+
+# Set to confirm when you try to exit IPython with an EOF (Control-D in Unix,
+# Control-Z/Enter in Windows). By typing 'exit' or 'quit', you can force a
+# direct exit without any confirmation.
+# c.TerminalInteractiveShell.confirm_exit = True
+
+# The shell program to be used for paging.
+# c.TerminalInteractiveShell.pager = 'less'
+
+# 
+# c.TerminalInteractiveShell.wildcards_case_sensitive = True
+
+# Deprecated, use PromptManager.justify
+# c.TerminalInteractiveShell.prompts_pad_left = True
+
+# The name of the logfile to use.
+# c.TerminalInteractiveShell.logfile = ''
+
+# 'all', 'last', 'last_expr' or 'none', specifying which nodes should be run
+# interactively (displaying output from expressions).
+# c.TerminalInteractiveShell.ast_node_interactivity = 'last_expr'
+
+# 
+# c.TerminalInteractiveShell.quiet = False
+
+# Save multi-line entries as one entry in readline history
+# c.TerminalInteractiveShell.multiline_history = True
+
+# Deprecated, use PromptManager.in_template
+# c.TerminalInteractiveShell.prompt_in1 = 'In [\\#]: '
+
+# 
+# c.TerminalInteractiveShell.readline_use = True
+
+# Enable magic commands to be called without the leading %.
+# c.TerminalInteractiveShell.automagic = True
+
+# The part of the banner to be printed before the profile
+# c.TerminalInteractiveShell.banner1 = 'Python 3.4.3 |Continuum Analytics, Inc.| (default, Mar  6 2015, 12:07:41) \nType "copyright", "credits" or "license" for more information.\n\nIPython 3.1.0 -- An enhanced Interactive Python.\nAnaconda is brought to you by Continuum Analytics.\nPlease check out: http://continuum.io/thanks and https://binstar.org\n?         -> Introduction and overview of IPython\'s features.\n%quickref -> Quick reference.\nhelp      -> Python\'s own help system.\nobject?   -> Details about \'object\', use \'object??\' for extra details.\n'
+
+# Make IPython automatically call any callable object even if you didn't type
+# explicit parentheses. For example, 'str 43' becomes 'str(43)' automatically.
+# The value can be '0' to disable the feature, '1' for 'smart' autocall, where
+# it is not applied if there are no more arguments on the line, and '2' for
+# 'full' autocall, where all callable objects are automatically called (even if
+# no arguments are present).
+# c.TerminalInteractiveShell.autocall = 0
+
+# Autoindent IPython code entered interactively.
+# c.TerminalInteractiveShell.autoindent = True
+
+# Set the color scheme (NoColor, Linux, or LightBG).
+# c.TerminalInteractiveShell.colors = 'LightBG'
+
+# Set the editor used by IPython (default to $EDITOR/vi/notepad).
+# c.TerminalInteractiveShell.editor = 'mate -w'
+
+# Use colors for displaying information about objects. Because this information
+# is passed through a pager (like 'less'), and some pagers get confused with
+# color codes, this capability can be turned off.
+# c.TerminalInteractiveShell.color_info = True
+
+# 
+# c.TerminalInteractiveShell.readline_parse_and_bind = ['tab: complete', '"\\C-l": clear-screen', 'set show-all-if-ambiguous on', '"\\C-o": tab-insert', '"\\C-r": reverse-search-history', '"\\C-s": forward-search-history', '"\\C-p": history-search-backward', '"\\C-n": history-search-forward', '"\\e[A": history-search-backward', '"\\e[B": history-search-forward', '"\\C-k": kill-line', '"\\C-u": unix-line-discard']
+
+# Deprecated, use PromptManager.in2_template
+# c.TerminalInteractiveShell.prompt_in2 = '   .\\D.: '
+
+# 
+# c.TerminalInteractiveShell.separate_out2 = ''
+
+# The part of the banner to be printed after the profile
+# c.TerminalInteractiveShell.banner2 = ''
+
+# Start logging to the given file in append mode. Use `logfile` to specify a log
+# file to **overwrite** logs to.
+# c.TerminalInteractiveShell.logappend = ''
+
+# Don't call post-execute functions that have failed in the past.
+# c.TerminalInteractiveShell.disable_failing_post_execute = False
+
+# Deprecated, use PromptManager.out_template
+# c.TerminalInteractiveShell.prompt_out = 'Out[\\#]: '
+
+# Enable deep (recursive) reloading by default. IPython can use the deep_reload
+# module which reloads changes in modules recursively (it replaces the reload()
+# function, so you don't need to change anything to use it). deep_reload()
+# forces a full reload of modules whose code may have changed, which the default
+# reload() function does not.  When deep_reload is off, IPython will use the
+# normal reload(), but deep_reload will still be available as dreload().
+# c.TerminalInteractiveShell.deep_reload = False
+
+# 
+# c.TerminalInteractiveShell.xmode = 'Context'
+
+# Show rewritten input, e.g. for autocall.
+# c.TerminalInteractiveShell.show_rewritten_input = True
+
+# Number of lines of your screen, used to control printing of very long strings.
+# Strings longer than this number of lines will be sent through a pager instead
+# of directly printed.  The default value for this is 0, which means IPython
+# will auto-detect your screen size every time it needs to print certain
+# potentially long strings (this doesn't change the behavior of the 'print'
+# keyword, it's only triggered internally). If for some reason this isn't
+# working well (it needs curses support), specify it yourself. Otherwise don't
+# change the default.
+# c.TerminalInteractiveShell.screen_length = 0
+
+# A list of ast.NodeTransformer subclass instances, which will be applied to
+# user input before code is run.
+# c.TerminalInteractiveShell.ast_transformers = []
+
+# Enable auto setting the terminal title.
+# c.TerminalInteractiveShell.term_title = False
+
+#------------------------------------------------------------------------------
+# PromptManager configuration
+#------------------------------------------------------------------------------
+
+# This is the primary interface for producing IPython's prompts.
+
+# 
+# c.PromptManager.color_scheme = 'Linux'
+
+# Continuation prompt.
+# c.PromptManager.in2_template = '   .\\D.: '
+
+# Input prompt.  '\#' will be transformed to the prompt number
+# c.PromptManager.in_template = 'In [\\#]: '
+
+# Output prompt. '\#' will be transformed to the prompt number
+# c.PromptManager.out_template = 'Out[\\#]: '
+
+# If True (default), each prompt will be right-aligned with the preceding one.
+# c.PromptManager.justify = True
+
+#------------------------------------------------------------------------------
+# HistoryManager configuration
+#------------------------------------------------------------------------------
+
+# A class to organize all history-related functionality in one place.
+
+# HistoryManager will inherit config from: HistoryAccessor
+
+# Options for configuring the SQLite connection
+# 
+# These options are passed as keyword args to sqlite3.connect when establishing
+# database conenctions.
+# c.HistoryManager.connection_options = {}
+
+# Should the history database include output? (default: no)
+# c.HistoryManager.db_log_output = False
+
+# enable the SQLite history
+# 
+# set enabled=False to disable the SQLite history, in which case there will be
+# no stored history, no SQLite connection, and no background saving thread.
+# This may be necessary in some threaded environments where IPython is embedded.
+# c.HistoryManager.enabled = True
+
+# Path to file to use for SQLite history database.
+# 
+# By default, IPython will put the history database in the IPython profile
+# directory.  If you would rather share one history among profiles, you can set
+# this value in each, so that they are consistent.
+# 
+# Due to an issue with fcntl, SQLite is known to misbehave on some NFS mounts.
+# If you see IPython hanging, try setting this to something on a local disk,
+# e.g::
+# 
+#     ipython --HistoryManager.hist_file=/tmp/ipython_hist.sqlite
+# c.HistoryManager.hist_file = ''
+
+# Write to database every x commands (higher values save disk access & power).
+# Values of 1 or less effectively disable caching.
+# c.HistoryManager.db_cache_size = 0
+
+#------------------------------------------------------------------------------
+# ProfileDir configuration
+#------------------------------------------------------------------------------
+
+# An object to manage the profile directory and its resources.
+# 
+# The profile directory is used by all IPython applications, to manage
+# configuration, logging and security.
+# 
+# This object knows how to find, create and manage these directories. This
+# should be used by any code that wants to handle profiles.
+
+# Set the profile location directly. This overrides the logic used by the
+# `profile` option.
+# c.ProfileDir.location = ''
+
+#------------------------------------------------------------------------------
+# PlainTextFormatter configuration
+#------------------------------------------------------------------------------
+
+# The default pretty-printer.
+# 
+# This uses :mod:`IPython.lib.pretty` to compute the format data of the object.
+# If the object cannot be pretty printed, :func:`repr` is used. See the
+# documentation of :mod:`IPython.lib.pretty` for details on how to write pretty
+# printers.  Here is a simple example::
+# 
+#     def dtype_pprinter(obj, p, cycle):
+#         if cycle:
+#             return p.text('dtype(...)')
+#         if hasattr(obj, 'fields'):
+#             if obj.fields is None:
+#                 p.text(repr(obj))
+#             else:
+#                 p.begin_group(7, 'dtype([')
+#                 for i, field in enumerate(obj.descr):
+#                     if i > 0:
+#                         p.text(',')
+#                         p.breakable()
+#                     p.pretty(field)
+#                 p.end_group(7, '])')
+
+# PlainTextFormatter will inherit config from: BaseFormatter
+
+# 
+# c.PlainTextFormatter.newline = '\n'
+
+# 
+# c.PlainTextFormatter.max_width = 79
+
+# 
+# c.PlainTextFormatter.verbose = False
+
+# 
+# c.PlainTextFormatter.pprint = True
+
+# 
+# c.PlainTextFormatter.singleton_printers = {}
+
+# 
+# c.PlainTextFormatter.type_printers = {}
+
+# Truncate large collections (lists, dicts, tuples, sets) to this size.
+# 
+# Set to 0 to disable truncation.
+# c.PlainTextFormatter.max_seq_length = 1000
+
+# 
+# c.PlainTextFormatter.deferred_printers = {}
+
+# 
+# c.PlainTextFormatter.float_precision = ''
+
+#------------------------------------------------------------------------------
+# IPCompleter configuration
+#------------------------------------------------------------------------------
+
+# Extension of the completer class with IPython-specific features
+
+# IPCompleter will inherit config from: Completer
+
+# Whether to merge completion results into a single list
+# 
+# If False, only the completion results from the first non-empty completer will
+# be returned.
+# c.IPCompleter.merge_completions = True
+
+# Activate greedy completion
+# 
+# This will enable completion on elements of lists, results of function calls,
+# etc., but can be unsafe because the code is actually evaluated on TAB.
+# c.IPCompleter.greedy = False
+
+# Instruct the completer to use __all__ for the completion
+# 
+# Specifically, when completing on ``object.<tab>``.
+# 
+# When True: only those names in obj.__all__ will be included.
+# 
+# When False [default]: the __all__ attribute is ignored
+# c.IPCompleter.limit_to__all__ = False
+
+# Instruct the completer to omit private method names
+# 
+# Specifically, when completing on ``object.<tab>``.
+# 
+# When 2 [default]: all names that start with '_' will be excluded.
+# 
+# When 1: all 'magic' names (``__foo__``) will be excluded.
+# 
+# When 0: nothing will be excluded.
+# c.IPCompleter.omit__names = 2
+
+#------------------------------------------------------------------------------
+# ScriptMagics configuration
+#------------------------------------------------------------------------------
+
+# Magics for talking to scripts
+# 
+# This defines a base `%%script` cell magic for running a cell with a program in
+# a subprocess, and registers a few top-level magics that call %%script with
+# common interpreters.
+
+# Extra script cell magics to define
+# 
+# This generates simple wrappers of `%%script foo` as `%%foo`.
+# 
+# If you want to add script magics that aren't on your path, specify them in
+# script_paths
+# c.ScriptMagics.script_magics = []
+
+# Dict mapping short 'ruby' names to full paths, such as '/opt/secret/bin/ruby'
+# 
+# Only necessary for items in script_magics where the default path will not find
+# the right interpreter.
+# c.ScriptMagics.script_paths = {}
+
+#------------------------------------------------------------------------------
+# StoreMagics configuration
+#------------------------------------------------------------------------------
+
+# Lightweight persistence for python variables.
+# 
+# Provides the %store magic.
+
+# If True, any %store-d variables will be automatically restored when IPython
+# starts.
+# c.StoreMagics.autorestore = False

--- a/jupyter_core/tests/dotipython/profile_default/ipython_console_config.py
+++ b/jupyter_core/tests/dotipython/profile_default/ipython_console_config.py
@@ -1,0 +1,531 @@
+# Configuration file for ipython-console.
+
+c = get_config()
+
+#------------------------------------------------------------------------------
+# ZMQTerminalIPythonApp configuration
+#------------------------------------------------------------------------------
+
+# ZMQTerminalIPythonApp will inherit config from: TerminalIPythonApp,
+# BaseIPythonApplication, Application, InteractiveShellApp, IPythonConsoleApp,
+# ConnectionFileMixin
+
+# Should variables loaded at startup (by startup files, exec_lines, etc.) be
+# hidden from tools like %who?
+# c.ZMQTerminalIPythonApp.hide_initial_ns = True
+
+# set the heartbeat port [default: random]
+# c.ZMQTerminalIPythonApp.hb_port = 0
+
+# A list of dotted module names of IPython extensions to load.
+# c.ZMQTerminalIPythonApp.extensions = []
+
+# Execute the given command string.
+# c.ZMQTerminalIPythonApp.code_to_run = ''
+
+# Path to the ssh key to use for logging in to the ssh server.
+# c.ZMQTerminalIPythonApp.sshkey = ''
+
+# The date format used by logging formatters for %(asctime)s
+# c.ZMQTerminalIPythonApp.log_datefmt = '%Y-%m-%d %H:%M:%S'
+
+# set the control (ROUTER) port [default: random]
+# c.ZMQTerminalIPythonApp.control_port = 0
+
+# Reraise exceptions encountered loading IPython extensions?
+# c.ZMQTerminalIPythonApp.reraise_ipython_extension_failures = False
+
+# Set the log level by value or name.
+# c.ZMQTerminalIPythonApp.log_level = 30
+
+# Run the file referenced by the PYTHONSTARTUP environment variable at IPython
+# startup.
+# c.ZMQTerminalIPythonApp.exec_PYTHONSTARTUP = True
+
+# Pre-load matplotlib and numpy for interactive use, selecting a particular
+# matplotlib backend and loop integration.
+# c.ZMQTerminalIPythonApp.pylab = None
+
+# Run the module as a script.
+# c.ZMQTerminalIPythonApp.module_to_run = ''
+
+# Whether to display a banner upon starting IPython.
+# c.ZMQTerminalIPythonApp.display_banner = True
+
+# dotted module name of an IPython extension to load.
+# c.ZMQTerminalIPythonApp.extra_extension = ''
+
+# Create a massive crash report when IPython encounters what may be an internal
+# error.  The default is to append a short message to the usual traceback
+# c.ZMQTerminalIPythonApp.verbose_crash = False
+
+# Whether to overwrite existing config files when copying
+# c.ZMQTerminalIPythonApp.overwrite = False
+
+# The IPython profile to use.
+# c.ZMQTerminalIPythonApp.profile = 'default'
+
+# If a command or file is given via the command-line, e.g. 'ipython foo.py',
+# start an interactive shell after executing the file or command.
+# c.ZMQTerminalIPythonApp.force_interact = False
+
+# List of files to run at IPython startup.
+# c.ZMQTerminalIPythonApp.exec_files = []
+
+# Start IPython quickly by skipping the loading of config files.
+# c.ZMQTerminalIPythonApp.quick = False
+
+# The Logging format template
+# c.ZMQTerminalIPythonApp.log_format = '[%(name)s]%(highlevel)s %(message)s'
+
+# Whether to install the default config files into the profile dir. If a new
+# profile is being created, and IPython contains config files for that profile,
+# then they will be staged into the new directory.  Otherwise, default config
+# files will be automatically generated.
+# c.ZMQTerminalIPythonApp.copy_config_files = False
+
+# set the stdin (ROUTER) port [default: random]
+# c.ZMQTerminalIPythonApp.stdin_port = 0
+
+# Path to an extra config file to load.
+# 
+# If specified, load this config file in addition to any other IPython config.
+# c.ZMQTerminalIPythonApp.extra_config_file = ''
+
+# lines of code to run at IPython startup.
+# c.ZMQTerminalIPythonApp.exec_lines = []
+
+# Enable GUI event loop integration with any of ('glut', 'gtk', 'gtk3', 'osx',
+# 'pyglet', 'qt', 'qt5', 'tk', 'wx').
+# c.ZMQTerminalIPythonApp.gui = None
+
+# A file to be run
+# c.ZMQTerminalIPythonApp.file_to_run = ''
+
+# Configure matplotlib for interactive use with the default matplotlib backend.
+# c.ZMQTerminalIPythonApp.matplotlib = None
+
+# Suppress warning messages about legacy config files
+# c.ZMQTerminalIPythonApp.ignore_old_config = False
+
+# set the iopub (PUB) port [default: random]
+# c.ZMQTerminalIPythonApp.iopub_port = 0
+
+# 
+# c.ZMQTerminalIPythonApp.transport = 'tcp'
+
+# JSON file in which to store connection info [default: kernel-<pid>.json]
+# 
+# This file will contain the IP, ports, and authentication key needed to connect
+# clients to this kernel. By default, this file will be created in the security
+# dir of the current profile, but can be specified by absolute path.
+# c.ZMQTerminalIPythonApp.connection_file = ''
+
+# The name of the IPython directory. This directory is used for logging
+# configuration (through profiles), history storage, etc. The default is usually
+# $HOME/.ipython. This option can also be specified through the environment
+# variable IPYTHONDIR.
+# c.ZMQTerminalIPythonApp.ipython_dir = ''
+
+# The SSH server to use to connect to the kernel.
+# c.ZMQTerminalIPythonApp.sshserver = ''
+
+# Set to display confirmation dialog on exit. You can always use 'exit' or
+# 'quit', to force a direct exit without any confirmation.
+# c.ZMQTerminalIPythonApp.confirm_exit = True
+
+# set the shell (ROUTER) port [default: random]
+# c.ZMQTerminalIPythonApp.shell_port = 0
+
+# The name of the default kernel to start.
+# c.ZMQTerminalIPythonApp.kernel_name = 'python'
+
+# If true, IPython will populate the user namespace with numpy, pylab, etc. and
+# an ``import *`` is done from numpy and pylab, when using pylab mode.
+# 
+# When False, pylab mode should not import any names into the user namespace.
+# c.ZMQTerminalIPythonApp.pylab_import_all = True
+
+# Connect to an already running kernel
+# c.ZMQTerminalIPythonApp.existing = ''
+
+# Set the kernel's IP address [default localhost]. If the IP address is
+# something other than localhost, then Consoles on other machines will be able
+# to connect to the Kernel, so be careful!
+# c.ZMQTerminalIPythonApp.ip = ''
+
+#------------------------------------------------------------------------------
+# ZMQTerminalInteractiveShell configuration
+#------------------------------------------------------------------------------
+
+# A subclass of TerminalInteractiveShell that uses the 0MQ kernel
+
+# ZMQTerminalInteractiveShell will inherit config from:
+# TerminalInteractiveShell, InteractiveShell
+
+# 
+# c.ZMQTerminalInteractiveShell.history_length = 10000
+
+# auto editing of files with syntax errors.
+# c.ZMQTerminalInteractiveShell.autoedit_syntax = False
+
+# If True, anything that would be passed to the pager will be displayed as
+# regular output instead.
+# c.ZMQTerminalInteractiveShell.display_page = False
+
+# 
+# c.ZMQTerminalInteractiveShell.debug = False
+
+# 'all', 'last', 'last_expr' or 'none', specifying which nodes should be run
+# interactively (displaying output from expressions).
+# c.ZMQTerminalInteractiveShell.ast_node_interactivity = 'last_expr'
+
+# Start logging to the default log file in overwrite mode. Use `logappend` to
+# specify a log file to **append** logs to.
+# c.ZMQTerminalInteractiveShell.logstart = False
+
+# Set the size of the output cache.  The default is 1000, you can change it
+# permanently in your config file.  Setting it to 0 completely disables the
+# caching system, and the minimum value accepted is 20 (if you provide a value
+# less than 20, it is reset to 0 and a warning is issued).  This limit is
+# defined because otherwise you'll spend more time re-flushing a too small cache
+# than working
+# c.ZMQTerminalInteractiveShell.cache_size = 1000
+
+# The shell program to be used for paging.
+# c.ZMQTerminalInteractiveShell.pager = 'less'
+
+# The name of the logfile to use.
+# c.ZMQTerminalInteractiveShell.logfile = ''
+
+# Save multi-line entries as one entry in readline history
+# c.ZMQTerminalInteractiveShell.multiline_history = True
+
+# 
+# c.ZMQTerminalInteractiveShell.readline_remove_delims = '-/~'
+
+# Enable magic commands to be called without the leading %.
+# c.ZMQTerminalInteractiveShell.automagic = True
+
+# Prefix to add to outputs coming from clients other than this one.
+# 
+# Only relevant if include_other_output is True.
+# c.ZMQTerminalInteractiveShell.other_output_prefix = '[remote] '
+
+# 
+# c.ZMQTerminalInteractiveShell.readline_parse_and_bind = ['tab: complete', '"\\C-l": clear-screen', 'set show-all-if-ambiguous on', '"\\C-o": tab-insert', '"\\C-r": reverse-search-history', '"\\C-s": forward-search-history', '"\\C-p": history-search-backward', '"\\C-n": history-search-forward', '"\\e[A": history-search-backward', '"\\e[B": history-search-forward', '"\\C-k": kill-line', '"\\C-u": unix-line-discard']
+
+# Use colors for displaying information about objects. Because this information
+# is passed through a pager (like 'less'), and some pagers get confused with
+# color codes, this capability can be turned off.
+# c.ZMQTerminalInteractiveShell.color_info = True
+
+# Callable object called via 'callable' image handler with one argument, `data`,
+# which is `msg["content"]["data"]` where `msg` is the message from iopub
+# channel.  For exmaple, you can find base64 encoded PNG data as
+# `data['image/png']`.
+# c.ZMQTerminalInteractiveShell.callable_image_handler = None
+
+# Command to invoke an image viewer program when you are using 'stream' image
+# handler.  This option is a list of string where the first element is the
+# command itself and reminders are the options for the command.  Raw image data
+# is given as STDIN to the program.
+# c.ZMQTerminalInteractiveShell.stream_image_handler = []
+
+# 
+# c.ZMQTerminalInteractiveShell.separate_out2 = ''
+
+# Autoindent IPython code entered interactively.
+# c.ZMQTerminalInteractiveShell.autoindent = True
+
+# The part of the banner to be printed after the profile
+# c.ZMQTerminalInteractiveShell.banner2 = ''
+
+# Don't call post-execute functions that have failed in the past.
+# c.ZMQTerminalInteractiveShell.disable_failing_post_execute = False
+
+# Deprecated, use PromptManager.out_template
+# c.ZMQTerminalInteractiveShell.prompt_out = 'Out[\\#]: '
+
+# 
+# c.ZMQTerminalInteractiveShell.object_info_string_level = 0
+
+# 
+# c.ZMQTerminalInteractiveShell.separate_out = ''
+
+# Automatically call the pdb debugger after every exception.
+# c.ZMQTerminalInteractiveShell.pdb = False
+
+# Deprecated, use PromptManager.in_template
+# c.ZMQTerminalInteractiveShell.prompt_in1 = 'In [\\#]: '
+
+# 
+# c.ZMQTerminalInteractiveShell.separate_in = '\n'
+
+# 
+# c.ZMQTerminalInteractiveShell.wildcards_case_sensitive = True
+
+# Enable auto setting the terminal title.
+# c.ZMQTerminalInteractiveShell.term_title = False
+
+# Enable deep (recursive) reloading by default. IPython can use the deep_reload
+# module which reloads changes in modules recursively (it replaces the reload()
+# function, so you don't need to change anything to use it). deep_reload()
+# forces a full reload of modules whose code may have changed, which the default
+# reload() function does not.  When deep_reload is off, IPython will use the
+# normal reload(), but deep_reload will still be available as dreload().
+# c.ZMQTerminalInteractiveShell.deep_reload = False
+
+# Deprecated, use PromptManager.in2_template
+# c.ZMQTerminalInteractiveShell.prompt_in2 = '   .\\D.: '
+
+# Whether to include output from clients other than this one sharing the same
+# kernel.
+# 
+# Outputs are not displayed until enter is pressed.
+# c.ZMQTerminalInteractiveShell.include_other_output = False
+
+# Preferred object representation MIME type in order.  First matched MIME type
+# will be used.
+# c.ZMQTerminalInteractiveShell.mime_preference = ['image/png', 'image/jpeg', 'image/svg+xml']
+
+# 
+# c.ZMQTerminalInteractiveShell.readline_use = True
+
+# Make IPython automatically call any callable object even if you didn't type
+# explicit parentheses. For example, 'str 43' becomes 'str(43)' automatically.
+# The value can be '0' to disable the feature, '1' for 'smart' autocall, where
+# it is not applied if there are no more arguments on the line, and '2' for
+# 'full' autocall, where all callable objects are automatically called (even if
+# no arguments are present).
+# c.ZMQTerminalInteractiveShell.autocall = 0
+
+# The part of the banner to be printed before the profile
+# c.ZMQTerminalInteractiveShell.banner1 = 'Python 3.4.3 |Continuum Analytics, Inc.| (default, Mar  6 2015, 12:07:41) \nType "copyright", "credits" or "license" for more information.\n\nIPython 3.1.0 -- An enhanced Interactive Python.\nAnaconda is brought to you by Continuum Analytics.\nPlease check out: http://continuum.io/thanks and https://binstar.org\n?         -> Introduction and overview of IPython\'s features.\n%quickref -> Quick reference.\nhelp      -> Python\'s own help system.\nobject?   -> Details about \'object\', use \'object??\' for extra details.\n'
+
+# Handler for image type output.  This is useful, for example, when connecting
+# to the kernel in which pylab inline backend is activated.  There are four
+# handlers defined.  'PIL': Use Python Imaging Library to popup image; 'stream':
+# Use an external program to show the image.  Image will be fed into the STDIN
+# of the program.  You will need to configure `stream_image_handler`;
+# 'tempfile': Use an external program to show the image.  Image will be saved in
+# a temporally file and the program is called with the temporally file.  You
+# will need to configure `tempfile_image_handler`; 'callable': You can set any
+# Python callable which is called with the image data.  You will need to
+# configure `callable_image_handler`.
+# c.ZMQTerminalInteractiveShell.image_handler = None
+
+# Set the color scheme (NoColor, Linux, or LightBG).
+# c.ZMQTerminalInteractiveShell.colors = 'LightBG'
+
+# Set the editor used by IPython (default to $EDITOR/vi/notepad).
+# c.ZMQTerminalInteractiveShell.editor = 'mate -w'
+
+# Show rewritten input, e.g. for autocall.
+# c.ZMQTerminalInteractiveShell.show_rewritten_input = True
+
+# 
+# c.ZMQTerminalInteractiveShell.xmode = 'Context'
+
+# 
+# c.ZMQTerminalInteractiveShell.quiet = False
+
+# A list of ast.NodeTransformer subclass instances, which will be applied to
+# user input before code is run.
+# c.ZMQTerminalInteractiveShell.ast_transformers = []
+
+# 
+# c.ZMQTerminalInteractiveShell.ipython_dir = ''
+
+# Set to confirm when you try to exit IPython with an EOF (Control-D in Unix,
+# Control-Z/Enter in Windows). By typing 'exit' or 'quit', you can force a
+# direct exit without any confirmation.
+# c.ZMQTerminalInteractiveShell.confirm_exit = True
+
+# Deprecated, use PromptManager.justify
+# c.ZMQTerminalInteractiveShell.prompts_pad_left = True
+
+# Timeout for giving up on a kernel (in seconds).
+# 
+# On first connect and restart, the console tests whether the kernel is running
+# and responsive by sending kernel_info_requests. This sets the timeout in
+# seconds for how long the kernel can take before being presumed dead.
+# c.ZMQTerminalInteractiveShell.kernel_timeout = 60
+
+# Number of lines of your screen, used to control printing of very long strings.
+# Strings longer than this number of lines will be sent through a pager instead
+# of directly printed.  The default value for this is 0, which means IPython
+# will auto-detect your screen size every time it needs to print certain
+# potentially long strings (this doesn't change the behavior of the 'print'
+# keyword, it's only triggered internally). If for some reason this isn't
+# working well (it needs curses support), specify it yourself. Otherwise don't
+# change the default.
+# c.ZMQTerminalInteractiveShell.screen_length = 0
+
+# Start logging to the given file in append mode. Use `logfile` to specify a log
+# file to **overwrite** logs to.
+# c.ZMQTerminalInteractiveShell.logappend = ''
+
+# Command to invoke an image viewer program when you are using 'tempfile' image
+# handler.  This option is a list of string where the first element is the
+# command itself and reminders are the options for the command.  You can use
+# {file} and {format} in the string to represent the location of the generated
+# image file and image format.
+# c.ZMQTerminalInteractiveShell.tempfile_image_handler = []
+
+#------------------------------------------------------------------------------
+# KernelManager configuration
+#------------------------------------------------------------------------------
+
+# Manages a single kernel in a subprocess on this host.
+# 
+# This version starts kernels with Popen.
+
+# KernelManager will inherit config from: ConnectionFileMixin
+
+# set the heartbeat port [default: random]
+# c.KernelManager.hb_port = 0
+
+# set the stdin (ROUTER) port [default: random]
+# c.KernelManager.stdin_port = 0
+
+# 
+# c.KernelManager.transport = 'tcp'
+
+# JSON file in which to store connection info [default: kernel-<pid>.json]
+# 
+# This file will contain the IP, ports, and authentication key needed to connect
+# clients to this kernel. By default, this file will be created in the security
+# dir of the current profile, but can be specified by absolute path.
+# c.KernelManager.connection_file = ''
+
+# set the control (ROUTER) port [default: random]
+# c.KernelManager.control_port = 0
+
+# set the shell (ROUTER) port [default: random]
+# c.KernelManager.shell_port = 0
+
+# Should we autorestart the kernel if it dies.
+# c.KernelManager.autorestart = False
+
+# DEPRECATED: Use kernel_name instead.
+# 
+# The Popen Command to launch the kernel. Override this if you have a custom
+# kernel. If kernel_cmd is specified in a configuration file, IPython does not
+# pass any arguments to the kernel, because it cannot make any assumptions about
+# the  arguments that the kernel understands. In particular, this means that the
+# kernel does not receive the option --debug if it given on the IPython command
+# line.
+# c.KernelManager.kernel_cmd = []
+
+# Set the kernel's IP address [default localhost]. If the IP address is
+# something other than localhost, then Consoles on other machines will be able
+# to connect to the Kernel, so be careful!
+# c.KernelManager.ip = ''
+
+# set the iopub (PUB) port [default: random]
+# c.KernelManager.iopub_port = 0
+
+#------------------------------------------------------------------------------
+# ProfileDir configuration
+#------------------------------------------------------------------------------
+
+# An object to manage the profile directory and its resources.
+# 
+# The profile directory is used by all IPython applications, to manage
+# configuration, logging and security.
+# 
+# This object knows how to find, create and manage these directories. This
+# should be used by any code that wants to handle profiles.
+
+# Set the profile location directly. This overrides the logic used by the
+# `profile` option.
+# c.ProfileDir.location = ''
+
+#------------------------------------------------------------------------------
+# Session configuration
+#------------------------------------------------------------------------------
+
+# Object for handling serialization and sending of messages.
+# 
+# The Session object handles building messages and sending them with ZMQ sockets
+# or ZMQStream objects.  Objects can communicate with each other over the
+# network via Session objects, and only need to work with the dict-based IPython
+# message spec. The Session will handle serialization/deserialization, security,
+# and metadata.
+# 
+# Sessions support configurable serialization via packer/unpacker traits, and
+# signing with HMAC digests via the key/keyfile traits.
+# 
+# Parameters ----------
+# 
+# debug : bool
+#     whether to trigger extra debugging statements
+# packer/unpacker : str : 'json', 'pickle' or import_string
+#     importstrings for methods to serialize message parts.  If just
+#     'json' or 'pickle', predefined JSON and pickle packers will be used.
+#     Otherwise, the entire importstring must be used.
+# 
+#     The functions must accept at least valid JSON input, and output *bytes*.
+# 
+#     For example, to use msgpack:
+#     packer = 'msgpack.packb', unpacker='msgpack.unpackb'
+# pack/unpack : callables
+#     You can also set the pack/unpack callables for serialization directly.
+# session : bytes
+#     the ID of this Session object.  The default is to generate a new UUID.
+# username : unicode
+#     username added to message headers.  The default is to ask the OS.
+# key : bytes
+#     The key used to initialize an HMAC signature.  If unset, messages
+#     will not be signed or checked.
+# keyfile : filepath
+#     The file containing a key.  If this is set, `key` will be initialized
+#     to the contents of the file.
+
+# The digest scheme used to construct the message signatures. Must have the form
+# 'hmac-HASH'.
+# c.Session.signature_scheme = 'hmac-sha256'
+
+# The maximum number of digests to remember.
+# 
+# The digest history will be culled when it exceeds this value.
+# c.Session.digest_history_size = 65536
+
+# The name of the unpacker for unserializing messages. Only used with custom
+# functions for `packer`.
+# c.Session.unpacker = 'json'
+
+# The name of the packer for serializing messages. Should be one of 'json',
+# 'pickle', or an import name for a custom callable serializer.
+# c.Session.packer = 'json'
+
+# Username for the Session. Default is your system username.
+# c.Session.username = 'minrk'
+
+# Debug output in the Session
+# c.Session.debug = False
+
+# path to file containing execution key.
+# c.Session.keyfile = ''
+
+# The maximum number of items for a container to be introspected for custom
+# serialization. Containers larger than this are pickled outright.
+# c.Session.item_threshold = 64
+
+# Threshold (in bytes) beyond which an object's buffer should be extracted to
+# avoid pickling.
+# c.Session.buffer_threshold = 1024
+
+# The UUID identifying this session.
+# c.Session.session = ''
+
+# Threshold (in bytes) beyond which a buffer should be sent without copying.
+# c.Session.copy_threshold = 65536
+
+# execution key, for signing messages.
+# c.Session.key = b''
+
+# Metadata dictionary, which serves as the default top-level metadata dict for
+# each message.
+# c.Session.metadata = {}

--- a/jupyter_core/tests/dotipython/profile_default/ipython_kernel_config.py
+++ b/jupyter_core/tests/dotipython/profile_default/ipython_kernel_config.py
@@ -1,0 +1,408 @@
+# Configuration file for ipython-kernel.
+
+c = get_config()
+
+#------------------------------------------------------------------------------
+# IPKernelApp configuration
+#------------------------------------------------------------------------------
+
+# IPython: an enhanced interactive Python shell.
+
+# IPKernelApp will inherit config from: BaseIPythonApplication, Application,
+# InteractiveShellApp, ConnectionFileMixin
+
+# Should variables loaded at startup (by startup files, exec_lines, etc.) be
+# hidden from tools like %who?
+# c.IPKernelApp.hide_initial_ns = True
+
+# The importstring for the DisplayHook factory
+# c.IPKernelApp.displayhook_class = 'IPython.kernel.zmq.displayhook.ZMQDisplayHook'
+
+# A list of dotted module names of IPython extensions to load.
+# c.IPKernelApp.extensions = []
+
+# Execute the given command string.
+# c.IPKernelApp.code_to_run = ''
+
+# redirect stderr to the null device
+# c.IPKernelApp.no_stderr = False
+
+# The date format used by logging formatters for %(asctime)s
+# c.IPKernelApp.log_datefmt = '%Y-%m-%d %H:%M:%S'
+
+# Whether to create profile dir if it doesn't exist
+# c.IPKernelApp.auto_create = False
+
+# Reraise exceptions encountered loading IPython extensions?
+# c.IPKernelApp.reraise_ipython_extension_failures = False
+
+# Set the log level by value or name.
+# c.IPKernelApp.log_level = 30
+
+# Run the file referenced by the PYTHONSTARTUP environment variable at IPython
+# startup.
+# c.IPKernelApp.exec_PYTHONSTARTUP = True
+
+# Pre-load matplotlib and numpy for interactive use, selecting a particular
+# matplotlib backend and loop integration.
+# c.IPKernelApp.pylab = None
+
+# Run the module as a script.
+# c.IPKernelApp.module_to_run = ''
+
+# The importstring for the OutStream factory
+# c.IPKernelApp.outstream_class = 'IPython.kernel.zmq.iostream.OutStream'
+
+# dotted module name of an IPython extension to load.
+# c.IPKernelApp.extra_extension = ''
+
+# Create a massive crash report when IPython encounters what may be an internal
+# error.  The default is to append a short message to the usual traceback
+# c.IPKernelApp.verbose_crash = False
+
+# Whether to overwrite existing config files when copying
+# c.IPKernelApp.overwrite = False
+
+# The IPython profile to use.
+# c.IPKernelApp.profile = 'default'
+
+# List of files to run at IPython startup.
+# c.IPKernelApp.exec_files = []
+
+# The Logging format template
+# c.IPKernelApp.log_format = '[%(name)s]%(highlevel)s %(message)s'
+
+# Whether to install the default config files into the profile dir. If a new
+# profile is being created, and IPython contains config files for that profile,
+# then they will be staged into the new directory.  Otherwise, default config
+# files will be automatically generated.
+# c.IPKernelApp.copy_config_files = False
+
+# set the stdin (ROUTER) port [default: random]
+# c.IPKernelApp.stdin_port = 0
+
+# Path to an extra config file to load.
+# 
+# If specified, load this config file in addition to any other IPython config.
+# c.IPKernelApp.extra_config_file = ''
+
+# lines of code to run at IPython startup.
+# c.IPKernelApp.exec_lines = []
+
+# set the control (ROUTER) port [default: random]
+# c.IPKernelApp.control_port = 0
+
+# set the heartbeat port [default: random]
+# c.IPKernelApp.hb_port = 0
+
+# Enable GUI event loop integration with any of ('glut', 'gtk', 'gtk3', 'osx',
+# 'pyglet', 'qt', 'qt5', 'tk', 'wx').
+# c.IPKernelApp.gui = None
+
+# A file to be run
+# c.IPKernelApp.file_to_run = ''
+
+# The name of the IPython directory. This directory is used for logging
+# configuration (through profiles), history storage, etc. The default is usually
+# $HOME/.ipython. This option can also be specified through the environment
+# variable IPYTHONDIR.
+# c.IPKernelApp.ipython_dir = ''
+
+# kill this process if its parent dies.  On Windows, the argument specifies the
+# HANDLE of the parent process, otherwise it is simply boolean.
+# c.IPKernelApp.parent_handle = 0
+
+# Configure matplotlib for interactive use with the default matplotlib backend.
+# c.IPKernelApp.matplotlib = None
+
+# set the iopub (PUB) port [default: random]
+# c.IPKernelApp.iopub_port = 0
+
+# redirect stdout to the null device
+# c.IPKernelApp.no_stdout = False
+
+# 
+# c.IPKernelApp.transport = 'tcp'
+
+# JSON file in which to store connection info [default: kernel-<pid>.json]
+# 
+# This file will contain the IP, ports, and authentication key needed to connect
+# clients to this kernel. By default, this file will be created in the security
+# dir of the current profile, but can be specified by absolute path.
+# c.IPKernelApp.connection_file = ''
+
+# The Kernel subclass to be used.
+# 
+# This should allow easy re-use of the IPKernelApp entry point to configure and
+# launch kernels other than IPython's own.
+# c.IPKernelApp.kernel_class = <class 'IPython.kernel.zmq.ipkernel.IPythonKernel'>
+
+# ONLY USED ON WINDOWS Interrupt this process when the parent is signaled.
+# c.IPKernelApp.interrupt = 0
+
+# set the shell (ROUTER) port [default: random]
+# c.IPKernelApp.shell_port = 0
+
+# If true, IPython will populate the user namespace with numpy, pylab, etc. and
+# an ``import *`` is done from numpy and pylab, when using pylab mode.
+# 
+# When False, pylab mode should not import any names into the user namespace.
+# c.IPKernelApp.pylab_import_all = True
+
+# Set the kernel's IP address [default localhost]. If the IP address is
+# something other than localhost, then Consoles on other machines will be able
+# to connect to the Kernel, so be careful!
+# c.IPKernelApp.ip = ''
+
+#------------------------------------------------------------------------------
+# IPythonKernel configuration
+#------------------------------------------------------------------------------
+
+# IPythonKernel will inherit config from: Kernel
+
+# 
+# c.IPythonKernel._execute_sleep = 0.0005
+
+# Whether to use appnope for compatiblity with OS X App Nap.
+# 
+# Only affects OS X >= 10.9.
+# c.IPythonKernel._darwin_app_nap = True
+
+# 
+# c.IPythonKernel._poll_interval = 0.05
+
+#------------------------------------------------------------------------------
+# ZMQInteractiveShell configuration
+#------------------------------------------------------------------------------
+
+# A subclass of InteractiveShell for ZMQ.
+
+# ZMQInteractiveShell will inherit config from: InteractiveShell
+
+# 
+# c.ZMQInteractiveShell.object_info_string_level = 0
+
+# 
+# c.ZMQInteractiveShell.separate_out = ''
+
+# Automatically call the pdb debugger after every exception.
+# c.ZMQInteractiveShell.pdb = False
+
+# 
+# c.ZMQInteractiveShell.ipython_dir = ''
+
+# 
+# c.ZMQInteractiveShell.history_length = 10000
+
+# 
+# c.ZMQInteractiveShell.readline_remove_delims = '-/~'
+
+# If True, anything that would be passed to the pager will be displayed as
+# regular output instead.
+# c.ZMQInteractiveShell.display_page = False
+
+# Deprecated, use PromptManager.in2_template
+# c.ZMQInteractiveShell.prompt_in2 = '   .\\D.: '
+
+# 
+# c.ZMQInteractiveShell.separate_in = '\n'
+
+# Start logging to the default log file in overwrite mode. Use `logappend` to
+# specify a log file to **append** logs to.
+# c.ZMQInteractiveShell.logstart = False
+
+# Set the size of the output cache.  The default is 1000, you can change it
+# permanently in your config file.  Setting it to 0 completely disables the
+# caching system, and the minimum value accepted is 20 (if you provide a value
+# less than 20, it is reset to 0 and a warning is issued).  This limit is
+# defined because otherwise you'll spend more time re-flushing a too small cache
+# than working
+# c.ZMQInteractiveShell.cache_size = 1000
+
+# 
+# c.ZMQInteractiveShell.wildcards_case_sensitive = True
+
+# The name of the logfile to use.
+# c.ZMQInteractiveShell.logfile = ''
+
+# 'all', 'last', 'last_expr' or 'none', specifying which nodes should be run
+# interactively (displaying output from expressions).
+# c.ZMQInteractiveShell.ast_node_interactivity = 'last_expr'
+
+# 
+# c.ZMQInteractiveShell.debug = False
+
+# 
+# c.ZMQInteractiveShell.quiet = False
+
+# Save multi-line entries as one entry in readline history
+# c.ZMQInteractiveShell.multiline_history = True
+
+# Deprecated, use PromptManager.in_template
+# c.ZMQInteractiveShell.prompt_in1 = 'In [\\#]: '
+
+# Enable magic commands to be called without the leading %.
+# c.ZMQInteractiveShell.automagic = True
+
+# The part of the banner to be printed before the profile
+# c.ZMQInteractiveShell.banner1 = 'Python 3.4.3 |Continuum Analytics, Inc.| (default, Mar  6 2015, 12:07:41) \nType "copyright", "credits" or "license" for more information.\n\nIPython 3.1.0 -- An enhanced Interactive Python.\nAnaconda is brought to you by Continuum Analytics.\nPlease check out: http://continuum.io/thanks and https://binstar.org\n?         -> Introduction and overview of IPython\'s features.\n%quickref -> Quick reference.\nhelp      -> Python\'s own help system.\nobject?   -> Details about \'object\', use \'object??\' for extra details.\n'
+
+# Make IPython automatically call any callable object even if you didn't type
+# explicit parentheses. For example, 'str 43' becomes 'str(43)' automatically.
+# The value can be '0' to disable the feature, '1' for 'smart' autocall, where
+# it is not applied if there are no more arguments on the line, and '2' for
+# 'full' autocall, where all callable objects are automatically called (even if
+# no arguments are present).
+# c.ZMQInteractiveShell.autocall = 0
+
+# 
+# c.ZMQInteractiveShell.readline_parse_and_bind = ['tab: complete', '"\\C-l": clear-screen', 'set show-all-if-ambiguous on', '"\\C-o": tab-insert', '"\\C-r": reverse-search-history', '"\\C-s": forward-search-history', '"\\C-p": history-search-backward', '"\\C-n": history-search-forward', '"\\e[A": history-search-backward', '"\\e[B": history-search-forward', '"\\C-k": kill-line', '"\\C-u": unix-line-discard']
+
+# Set the color scheme (NoColor, Linux, or LightBG).
+# c.ZMQInteractiveShell.colors = 'LightBG'
+
+# Use colors for displaying information about objects. Because this information
+# is passed through a pager (like 'less'), and some pagers get confused with
+# color codes, this capability can be turned off.
+# c.ZMQInteractiveShell.color_info = True
+
+# Show rewritten input, e.g. for autocall.
+# c.ZMQInteractiveShell.show_rewritten_input = True
+
+# 
+# c.ZMQInteractiveShell.xmode = 'Context'
+
+# 
+# c.ZMQInteractiveShell.separate_out2 = ''
+
+# The part of the banner to be printed after the profile
+# c.ZMQInteractiveShell.banner2 = ''
+
+# Start logging to the given file in append mode. Use `logfile` to specify a log
+# file to **overwrite** logs to.
+# c.ZMQInteractiveShell.logappend = ''
+
+# Don't call post-execute functions that have failed in the past.
+# c.ZMQInteractiveShell.disable_failing_post_execute = False
+
+# Deprecated, use PromptManager.out_template
+# c.ZMQInteractiveShell.prompt_out = 'Out[\\#]: '
+
+# Enable deep (recursive) reloading by default. IPython can use the deep_reload
+# module which reloads changes in modules recursively (it replaces the reload()
+# function, so you don't need to change anything to use it). deep_reload()
+# forces a full reload of modules whose code may have changed, which the default
+# reload() function does not.  When deep_reload is off, IPython will use the
+# normal reload(), but deep_reload will still be available as dreload().
+# c.ZMQInteractiveShell.deep_reload = False
+
+# Deprecated, use PromptManager.justify
+# c.ZMQInteractiveShell.prompts_pad_left = True
+
+# A list of ast.NodeTransformer subclass instances, which will be applied to
+# user input before code is run.
+# c.ZMQInteractiveShell.ast_transformers = []
+
+#------------------------------------------------------------------------------
+# ProfileDir configuration
+#------------------------------------------------------------------------------
+
+# An object to manage the profile directory and its resources.
+# 
+# The profile directory is used by all IPython applications, to manage
+# configuration, logging and security.
+# 
+# This object knows how to find, create and manage these directories. This
+# should be used by any code that wants to handle profiles.
+
+# Set the profile location directly. This overrides the logic used by the
+# `profile` option.
+# c.ProfileDir.location = ''
+
+#------------------------------------------------------------------------------
+# Session configuration
+#------------------------------------------------------------------------------
+
+# Object for handling serialization and sending of messages.
+# 
+# The Session object handles building messages and sending them with ZMQ sockets
+# or ZMQStream objects.  Objects can communicate with each other over the
+# network via Session objects, and only need to work with the dict-based IPython
+# message spec. The Session will handle serialization/deserialization, security,
+# and metadata.
+# 
+# Sessions support configurable serialization via packer/unpacker traits, and
+# signing with HMAC digests via the key/keyfile traits.
+# 
+# Parameters ----------
+# 
+# debug : bool
+#     whether to trigger extra debugging statements
+# packer/unpacker : str : 'json', 'pickle' or import_string
+#     importstrings for methods to serialize message parts.  If just
+#     'json' or 'pickle', predefined JSON and pickle packers will be used.
+#     Otherwise, the entire importstring must be used.
+# 
+#     The functions must accept at least valid JSON input, and output *bytes*.
+# 
+#     For example, to use msgpack:
+#     packer = 'msgpack.packb', unpacker='msgpack.unpackb'
+# pack/unpack : callables
+#     You can also set the pack/unpack callables for serialization directly.
+# session : bytes
+#     the ID of this Session object.  The default is to generate a new UUID.
+# username : unicode
+#     username added to message headers.  The default is to ask the OS.
+# key : bytes
+#     The key used to initialize an HMAC signature.  If unset, messages
+#     will not be signed or checked.
+# keyfile : filepath
+#     The file containing a key.  If this is set, `key` will be initialized
+#     to the contents of the file.
+
+# The digest scheme used to construct the message signatures. Must have the form
+# 'hmac-HASH'.
+# c.Session.signature_scheme = 'hmac-sha256'
+
+# The maximum number of digests to remember.
+# 
+# The digest history will be culled when it exceeds this value.
+# c.Session.digest_history_size = 65536
+
+# The name of the unpacker for unserializing messages. Only used with custom
+# functions for `packer`.
+# c.Session.unpacker = 'json'
+
+# The name of the packer for serializing messages. Should be one of 'json',
+# 'pickle', or an import name for a custom callable serializer.
+# c.Session.packer = 'json'
+
+# Username for the Session. Default is your system username.
+# c.Session.username = 'minrk'
+
+# Debug output in the Session
+# c.Session.debug = False
+
+# path to file containing execution key.
+# c.Session.keyfile = ''
+
+# The maximum number of items for a container to be introspected for custom
+# serialization. Containers larger than this are pickled outright.
+# c.Session.item_threshold = 64
+
+# Threshold (in bytes) beyond which an object's buffer should be extracted to
+# avoid pickling.
+# c.Session.buffer_threshold = 1024
+
+# The UUID identifying this session.
+# c.Session.session = ''
+
+# Threshold (in bytes) beyond which a buffer should be sent without copying.
+# c.Session.copy_threshold = 65536
+
+# execution key, for signing messages.
+# c.Session.key = b''
+
+# Metadata dictionary, which serves as the default top-level metadata dict for
+# each message.
+# c.Session.metadata = {}

--- a/jupyter_core/tests/dotipython/profile_default/ipython_nbconvert_config.py
+++ b/jupyter_core/tests/dotipython/profile_default/ipython_nbconvert_config.py
@@ -1,0 +1,1 @@
+c.NbConvertApp.post_processors = []

--- a/jupyter_core/tests/dotipython/profile_default/ipython_notebook_config.py
+++ b/jupyter_core/tests/dotipython/profile_default/ipython_notebook_config.py
@@ -1,0 +1,1 @@
+c.NotebookApp.open_browser = False

--- a/jupyter_core/tests/dotipython/profile_default/static/custom/custom.css
+++ b/jupyter_core/tests/dotipython/profile_default/static/custom/custom.css
@@ -1,0 +1,7 @@
+/*
+Placeholder for custom user CSS
+
+mainly to be overridden in profile/static/custom/custom.css
+
+This will always be an empty file in IPython
+*/

--- a/jupyter_core/tests/dotipython/profile_default/static/custom/custom.js
+++ b/jupyter_core/tests/dotipython/profile_default/static/custom/custom.js
@@ -1,0 +1,82 @@
+// leave at least 2 line with only a star on it below, or doc generation fails
+/**
+ *
+ *
+ * Placeholder for custom user javascript
+ * mainly to be overridden in profile/static/custom/custom.js
+ * This will always be an empty file in IPython
+ *
+ * User could add any javascript in the `profile/static/custom/custom.js` file.
+ * It will be executed by the ipython notebook at load time.
+ *
+ * Same thing with `profile/static/custom/custom.css` to inject custom css into the notebook.
+ *
+ *
+ * The object available at load time depend on the version of IPython in use.
+ * there is no guaranties of API stability.
+ *
+ * The example below explain the principle, and might not be valid.
+ *
+ * Instances are created after the loading of this file and might need to be accessed using events:
+ *     define([
+ *        'base/js/namespace',
+ *        'base/js/events'
+ *     ], function(IPython, events) {
+ *         events.on("app_initialized.NotebookApp", function () {
+ *             IPython.keyboard_manager....
+ *         });
+ *     });
+ *
+ * __Example 1:__
+ *
+ * Create a custom button in toolbar that execute `%qtconsole` in kernel
+ * and hence open a qtconsole attached to the same kernel as the current notebook
+ *
+ *    define([
+ *        'base/js/namespace',
+ *        'base/js/events'
+ *    ], function(IPython, events) {
+ *        events.on('app_initialized.NotebookApp', function(){
+ *            IPython.toolbar.add_buttons_group([
+ *                {
+ *                    'label'   : 'run qtconsole',
+ *                    'icon'    : 'icon-terminal', // select your icon from http://fortawesome.github.io/Font-Awesome/icons
+ *                    'callback': function () {
+ *                        IPython.notebook.kernel.execute('%qtconsole')
+ *                    }
+ *                }
+ *                // add more button here if needed.
+ *                ]);
+ *        });
+ *    });
+ *
+ * __Example 2:__
+ *
+ * At the completion of the dashboard loading, load an unofficial javascript extension
+ * that is installed in profile/static/custom/
+ *
+ *    define([
+ *        'base/js/events'
+ *    ], function(events) {
+ *        events.on('app_initialized.DashboardApp', function(){
+ *            require(['custom/unofficial_extension.js'])
+ *        });
+ *    });
+ *
+ * __Example 3:__
+ *
+ *  Use `jQuery.getScript(url [, success(script, textStatus, jqXHR)] );`
+ *  to load custom script into the notebook.
+ *
+ *    // to load the metadata ui extension example.
+ *    $.getScript('/static/notebook/js/celltoolbarpresets/example.js');
+ *    // or
+ *    // to load the metadata ui extension to control slideshow mode / reveal js for nbconvert
+ *    $.getScript('/static/notebook/js/celltoolbarpresets/slideshow.js');
+ *
+ *
+ * @module IPython
+ * @namespace IPython
+ * @class customjs
+ * @static
+ */

--- a/jupyter_core/tests/dotipython_empty/profile_default/ipython_config.py
+++ b/jupyter_core/tests/dotipython_empty/profile_default/ipython_config.py
@@ -1,0 +1,549 @@
+# Configuration file for ipython.
+
+c = get_config()
+
+#------------------------------------------------------------------------------
+# InteractiveShellApp configuration
+#------------------------------------------------------------------------------
+
+# A Mixin for applications that start InteractiveShell instances.
+# 
+# Provides configurables for loading extensions and executing files as part of
+# configuring a Shell environment.
+# 
+# The following methods should be called by the :meth:`initialize` method of the
+# subclass:
+# 
+#   - :meth:`init_path`
+#   - :meth:`init_shell` (to be implemented by the subclass)
+#   - :meth:`init_gui_pylab`
+#   - :meth:`init_extensions`
+#   - :meth:`init_code`
+
+# lines of code to run at IPython startup.
+# c.InteractiveShellApp.exec_lines = []
+
+# Should variables loaded at startup (by startup files, exec_lines, etc.) be
+# hidden from tools like %who?
+# c.InteractiveShellApp.hide_initial_ns = True
+
+# A list of dotted module names of IPython extensions to load.
+# c.InteractiveShellApp.extensions = []
+
+# Enable GUI event loop integration with any of ('glut', 'gtk', 'gtk3', 'osx',
+# 'pyglet', 'qt', 'qt5', 'tk', 'wx').
+# c.InteractiveShellApp.gui = None
+
+# A file to be run
+# c.InteractiveShellApp.file_to_run = ''
+
+# Configure matplotlib for interactive use with the default matplotlib backend.
+# c.InteractiveShellApp.matplotlib = None
+
+# Reraise exceptions encountered loading IPython extensions?
+# c.InteractiveShellApp.reraise_ipython_extension_failures = False
+
+# Run the file referenced by the PYTHONSTARTUP environment variable at IPython
+# startup.
+# c.InteractiveShellApp.exec_PYTHONSTARTUP = True
+
+# Pre-load matplotlib and numpy for interactive use, selecting a particular
+# matplotlib backend and loop integration.
+# c.InteractiveShellApp.pylab = None
+
+# Run the module as a script.
+# c.InteractiveShellApp.module_to_run = ''
+
+# dotted module name of an IPython extension to load.
+# c.InteractiveShellApp.extra_extension = ''
+
+# List of files to run at IPython startup.
+# c.InteractiveShellApp.exec_files = []
+
+# If true, IPython will populate the user namespace with numpy, pylab, etc. and
+# an ``import *`` is done from numpy and pylab, when using pylab mode.
+# 
+# When False, pylab mode should not import any names into the user namespace.
+# c.InteractiveShellApp.pylab_import_all = True
+
+# Execute the given command string.
+# c.InteractiveShellApp.code_to_run = ''
+
+#------------------------------------------------------------------------------
+# TerminalIPythonApp configuration
+#------------------------------------------------------------------------------
+
+# TerminalIPythonApp will inherit config from: BaseIPythonApplication,
+# Application, InteractiveShellApp
+
+# Should variables loaded at startup (by startup files, exec_lines, etc.) be
+# hidden from tools like %who?
+# c.TerminalIPythonApp.hide_initial_ns = True
+
+# A list of dotted module names of IPython extensions to load.
+# c.TerminalIPythonApp.extensions = []
+
+# Execute the given command string.
+# c.TerminalIPythonApp.code_to_run = ''
+
+# The date format used by logging formatters for %(asctime)s
+# c.TerminalIPythonApp.log_datefmt = '%Y-%m-%d %H:%M:%S'
+
+# Reraise exceptions encountered loading IPython extensions?
+# c.TerminalIPythonApp.reraise_ipython_extension_failures = False
+
+# Set the log level by value or name.
+# c.TerminalIPythonApp.log_level = 30
+
+# Run the file referenced by the PYTHONSTARTUP environment variable at IPython
+# startup.
+# c.TerminalIPythonApp.exec_PYTHONSTARTUP = True
+
+# Pre-load matplotlib and numpy for interactive use, selecting a particular
+# matplotlib backend and loop integration.
+# c.TerminalIPythonApp.pylab = None
+
+# Run the module as a script.
+# c.TerminalIPythonApp.module_to_run = ''
+
+# Whether to display a banner upon starting IPython.
+# c.TerminalIPythonApp.display_banner = True
+
+# dotted module name of an IPython extension to load.
+# c.TerminalIPythonApp.extra_extension = ''
+
+# Create a massive crash report when IPython encounters what may be an internal
+# error.  The default is to append a short message to the usual traceback
+# c.TerminalIPythonApp.verbose_crash = False
+
+# Whether to overwrite existing config files when copying
+# c.TerminalIPythonApp.overwrite = False
+
+# The IPython profile to use.
+# c.TerminalIPythonApp.profile = 'default'
+
+# If a command or file is given via the command-line, e.g. 'ipython foo.py',
+# start an interactive shell after executing the file or command.
+# c.TerminalIPythonApp.force_interact = False
+
+# List of files to run at IPython startup.
+# c.TerminalIPythonApp.exec_files = []
+
+# Start IPython quickly by skipping the loading of config files.
+# c.TerminalIPythonApp.quick = False
+
+# The Logging format template
+# c.TerminalIPythonApp.log_format = '[%(name)s]%(highlevel)s %(message)s'
+
+# Whether to install the default config files into the profile dir. If a new
+# profile is being created, and IPython contains config files for that profile,
+# then they will be staged into the new directory.  Otherwise, default config
+# files will be automatically generated.
+# c.TerminalIPythonApp.copy_config_files = False
+
+# Path to an extra config file to load.
+# 
+# If specified, load this config file in addition to any other IPython config.
+# c.TerminalIPythonApp.extra_config_file = ''
+
+# lines of code to run at IPython startup.
+# c.TerminalIPythonApp.exec_lines = []
+
+# Enable GUI event loop integration with any of ('glut', 'gtk', 'gtk3', 'osx',
+# 'pyglet', 'qt', 'qt5', 'tk', 'wx').
+# c.TerminalIPythonApp.gui = None
+
+# A file to be run
+# c.TerminalIPythonApp.file_to_run = ''
+
+# Configure matplotlib for interactive use with the default matplotlib backend.
+# c.TerminalIPythonApp.matplotlib = None
+
+# Suppress warning messages about legacy config files
+# c.TerminalIPythonApp.ignore_old_config = False
+
+# The name of the IPython directory. This directory is used for logging
+# configuration (through profiles), history storage, etc. The default is usually
+# $HOME/.ipython. This option can also be specified through the environment
+# variable IPYTHONDIR.
+# c.TerminalIPythonApp.ipython_dir = ''
+
+# If true, IPython will populate the user namespace with numpy, pylab, etc. and
+# an ``import *`` is done from numpy and pylab, when using pylab mode.
+# 
+# When False, pylab mode should not import any names into the user namespace.
+# c.TerminalIPythonApp.pylab_import_all = True
+
+#------------------------------------------------------------------------------
+# TerminalInteractiveShell configuration
+#------------------------------------------------------------------------------
+
+# TerminalInteractiveShell will inherit config from: InteractiveShell
+
+# 
+# c.TerminalInteractiveShell.object_info_string_level = 0
+
+# 
+# c.TerminalInteractiveShell.separate_out = ''
+
+# Automatically call the pdb debugger after every exception.
+# c.TerminalInteractiveShell.pdb = False
+
+# 
+# c.TerminalInteractiveShell.ipython_dir = ''
+
+# 
+# c.TerminalInteractiveShell.history_length = 10000
+
+# 
+# c.TerminalInteractiveShell.readline_remove_delims = '-/~'
+
+# auto editing of files with syntax errors.
+# c.TerminalInteractiveShell.autoedit_syntax = False
+
+# If True, anything that would be passed to the pager will be displayed as
+# regular output instead.
+# c.TerminalInteractiveShell.display_page = False
+
+# 
+# c.TerminalInteractiveShell.debug = False
+
+# 
+# c.TerminalInteractiveShell.separate_in = '\n'
+
+# Start logging to the default log file in overwrite mode. Use `logappend` to
+# specify a log file to **append** logs to.
+# c.TerminalInteractiveShell.logstart = False
+
+# Set the size of the output cache.  The default is 1000, you can change it
+# permanently in your config file.  Setting it to 0 completely disables the
+# caching system, and the minimum value accepted is 20 (if you provide a value
+# less than 20, it is reset to 0 and a warning is issued).  This limit is
+# defined because otherwise you'll spend more time re-flushing a too small cache
+# than working
+# c.TerminalInteractiveShell.cache_size = 1000
+
+# Set to confirm when you try to exit IPython with an EOF (Control-D in Unix,
+# Control-Z/Enter in Windows). By typing 'exit' or 'quit', you can force a
+# direct exit without any confirmation.
+# c.TerminalInteractiveShell.confirm_exit = True
+
+# The shell program to be used for paging.
+# c.TerminalInteractiveShell.pager = 'less'
+
+# 
+# c.TerminalInteractiveShell.wildcards_case_sensitive = True
+
+# Deprecated, use PromptManager.justify
+# c.TerminalInteractiveShell.prompts_pad_left = True
+
+# The name of the logfile to use.
+# c.TerminalInteractiveShell.logfile = ''
+
+# 'all', 'last', 'last_expr' or 'none', specifying which nodes should be run
+# interactively (displaying output from expressions).
+# c.TerminalInteractiveShell.ast_node_interactivity = 'last_expr'
+
+# 
+# c.TerminalInteractiveShell.quiet = False
+
+# Save multi-line entries as one entry in readline history
+# c.TerminalInteractiveShell.multiline_history = True
+
+# Deprecated, use PromptManager.in_template
+# c.TerminalInteractiveShell.prompt_in1 = 'In [\\#]: '
+
+# 
+# c.TerminalInteractiveShell.readline_use = True
+
+# Enable magic commands to be called without the leading %.
+# c.TerminalInteractiveShell.automagic = True
+
+# The part of the banner to be printed before the profile
+# c.TerminalInteractiveShell.banner1 = 'Python 3.4.3 |Continuum Analytics, Inc.| (default, Mar  6 2015, 12:07:41) \nType "copyright", "credits" or "license" for more information.\n\nIPython 3.1.0 -- An enhanced Interactive Python.\nAnaconda is brought to you by Continuum Analytics.\nPlease check out: http://continuum.io/thanks and https://binstar.org\n?         -> Introduction and overview of IPython\'s features.\n%quickref -> Quick reference.\nhelp      -> Python\'s own help system.\nobject?   -> Details about \'object\', use \'object??\' for extra details.\n'
+
+# Make IPython automatically call any callable object even if you didn't type
+# explicit parentheses. For example, 'str 43' becomes 'str(43)' automatically.
+# The value can be '0' to disable the feature, '1' for 'smart' autocall, where
+# it is not applied if there are no more arguments on the line, and '2' for
+# 'full' autocall, where all callable objects are automatically called (even if
+# no arguments are present).
+# c.TerminalInteractiveShell.autocall = 0
+
+# Autoindent IPython code entered interactively.
+# c.TerminalInteractiveShell.autoindent = True
+
+# Set the color scheme (NoColor, Linux, or LightBG).
+# c.TerminalInteractiveShell.colors = 'LightBG'
+
+# Set the editor used by IPython (default to $EDITOR/vi/notepad).
+# c.TerminalInteractiveShell.editor = 'mate -w'
+
+# Use colors for displaying information about objects. Because this information
+# is passed through a pager (like 'less'), and some pagers get confused with
+# color codes, this capability can be turned off.
+# c.TerminalInteractiveShell.color_info = True
+
+# 
+# c.TerminalInteractiveShell.readline_parse_and_bind = ['tab: complete', '"\\C-l": clear-screen', 'set show-all-if-ambiguous on', '"\\C-o": tab-insert', '"\\C-r": reverse-search-history', '"\\C-s": forward-search-history', '"\\C-p": history-search-backward', '"\\C-n": history-search-forward', '"\\e[A": history-search-backward', '"\\e[B": history-search-forward', '"\\C-k": kill-line', '"\\C-u": unix-line-discard']
+
+# Deprecated, use PromptManager.in2_template
+# c.TerminalInteractiveShell.prompt_in2 = '   .\\D.: '
+
+# 
+# c.TerminalInteractiveShell.separate_out2 = ''
+
+# The part of the banner to be printed after the profile
+# c.TerminalInteractiveShell.banner2 = ''
+
+# Start logging to the given file in append mode. Use `logfile` to specify a log
+# file to **overwrite** logs to.
+# c.TerminalInteractiveShell.logappend = ''
+
+# Don't call post-execute functions that have failed in the past.
+# c.TerminalInteractiveShell.disable_failing_post_execute = False
+
+# Deprecated, use PromptManager.out_template
+# c.TerminalInteractiveShell.prompt_out = 'Out[\\#]: '
+
+# Enable deep (recursive) reloading by default. IPython can use the deep_reload
+# module which reloads changes in modules recursively (it replaces the reload()
+# function, so you don't need to change anything to use it). deep_reload()
+# forces a full reload of modules whose code may have changed, which the default
+# reload() function does not.  When deep_reload is off, IPython will use the
+# normal reload(), but deep_reload will still be available as dreload().
+# c.TerminalInteractiveShell.deep_reload = False
+
+# 
+# c.TerminalInteractiveShell.xmode = 'Context'
+
+# Show rewritten input, e.g. for autocall.
+# c.TerminalInteractiveShell.show_rewritten_input = True
+
+# Number of lines of your screen, used to control printing of very long strings.
+# Strings longer than this number of lines will be sent through a pager instead
+# of directly printed.  The default value for this is 0, which means IPython
+# will auto-detect your screen size every time it needs to print certain
+# potentially long strings (this doesn't change the behavior of the 'print'
+# keyword, it's only triggered internally). If for some reason this isn't
+# working well (it needs curses support), specify it yourself. Otherwise don't
+# change the default.
+# c.TerminalInteractiveShell.screen_length = 0
+
+# A list of ast.NodeTransformer subclass instances, which will be applied to
+# user input before code is run.
+# c.TerminalInteractiveShell.ast_transformers = []
+
+# Enable auto setting the terminal title.
+# c.TerminalInteractiveShell.term_title = False
+
+#------------------------------------------------------------------------------
+# PromptManager configuration
+#------------------------------------------------------------------------------
+
+# This is the primary interface for producing IPython's prompts.
+
+# 
+# c.PromptManager.color_scheme = 'Linux'
+
+# Continuation prompt.
+# c.PromptManager.in2_template = '   .\\D.: '
+
+# Input prompt.  '\#' will be transformed to the prompt number
+# c.PromptManager.in_template = 'In [\\#]: '
+
+# Output prompt. '\#' will be transformed to the prompt number
+# c.PromptManager.out_template = 'Out[\\#]: '
+
+# If True (default), each prompt will be right-aligned with the preceding one.
+# c.PromptManager.justify = True
+
+#------------------------------------------------------------------------------
+# HistoryManager configuration
+#------------------------------------------------------------------------------
+
+# A class to organize all history-related functionality in one place.
+
+# HistoryManager will inherit config from: HistoryAccessor
+
+# Options for configuring the SQLite connection
+# 
+# These options are passed as keyword args to sqlite3.connect when establishing
+# database conenctions.
+# c.HistoryManager.connection_options = {}
+
+# Should the history database include output? (default: no)
+# c.HistoryManager.db_log_output = False
+
+# enable the SQLite history
+# 
+# set enabled=False to disable the SQLite history, in which case there will be
+# no stored history, no SQLite connection, and no background saving thread.
+# This may be necessary in some threaded environments where IPython is embedded.
+# c.HistoryManager.enabled = True
+
+# Path to file to use for SQLite history database.
+# 
+# By default, IPython will put the history database in the IPython profile
+# directory.  If you would rather share one history among profiles, you can set
+# this value in each, so that they are consistent.
+# 
+# Due to an issue with fcntl, SQLite is known to misbehave on some NFS mounts.
+# If you see IPython hanging, try setting this to something on a local disk,
+# e.g::
+# 
+#     ipython --HistoryManager.hist_file=/tmp/ipython_hist.sqlite
+# c.HistoryManager.hist_file = ''
+
+# Write to database every x commands (higher values save disk access & power).
+# Values of 1 or less effectively disable caching.
+# c.HistoryManager.db_cache_size = 0
+
+#------------------------------------------------------------------------------
+# ProfileDir configuration
+#------------------------------------------------------------------------------
+
+# An object to manage the profile directory and its resources.
+# 
+# The profile directory is used by all IPython applications, to manage
+# configuration, logging and security.
+# 
+# This object knows how to find, create and manage these directories. This
+# should be used by any code that wants to handle profiles.
+
+# Set the profile location directly. This overrides the logic used by the
+# `profile` option.
+# c.ProfileDir.location = ''
+
+#------------------------------------------------------------------------------
+# PlainTextFormatter configuration
+#------------------------------------------------------------------------------
+
+# The default pretty-printer.
+# 
+# This uses :mod:`IPython.lib.pretty` to compute the format data of the object.
+# If the object cannot be pretty printed, :func:`repr` is used. See the
+# documentation of :mod:`IPython.lib.pretty` for details on how to write pretty
+# printers.  Here is a simple example::
+# 
+#     def dtype_pprinter(obj, p, cycle):
+#         if cycle:
+#             return p.text('dtype(...)')
+#         if hasattr(obj, 'fields'):
+#             if obj.fields is None:
+#                 p.text(repr(obj))
+#             else:
+#                 p.begin_group(7, 'dtype([')
+#                 for i, field in enumerate(obj.descr):
+#                     if i > 0:
+#                         p.text(',')
+#                         p.breakable()
+#                     p.pretty(field)
+#                 p.end_group(7, '])')
+
+# PlainTextFormatter will inherit config from: BaseFormatter
+
+# 
+# c.PlainTextFormatter.newline = '\n'
+
+# 
+# c.PlainTextFormatter.max_width = 79
+
+# 
+# c.PlainTextFormatter.verbose = False
+
+# 
+# c.PlainTextFormatter.pprint = True
+
+# 
+# c.PlainTextFormatter.singleton_printers = {}
+
+# 
+# c.PlainTextFormatter.type_printers = {}
+
+# Truncate large collections (lists, dicts, tuples, sets) to this size.
+# 
+# Set to 0 to disable truncation.
+# c.PlainTextFormatter.max_seq_length = 1000
+
+# 
+# c.PlainTextFormatter.deferred_printers = {}
+
+# 
+# c.PlainTextFormatter.float_precision = ''
+
+#------------------------------------------------------------------------------
+# IPCompleter configuration
+#------------------------------------------------------------------------------
+
+# Extension of the completer class with IPython-specific features
+
+# IPCompleter will inherit config from: Completer
+
+# Whether to merge completion results into a single list
+# 
+# If False, only the completion results from the first non-empty completer will
+# be returned.
+# c.IPCompleter.merge_completions = True
+
+# Activate greedy completion
+# 
+# This will enable completion on elements of lists, results of function calls,
+# etc., but can be unsafe because the code is actually evaluated on TAB.
+# c.IPCompleter.greedy = False
+
+# Instruct the completer to use __all__ for the completion
+# 
+# Specifically, when completing on ``object.<tab>``.
+# 
+# When True: only those names in obj.__all__ will be included.
+# 
+# When False [default]: the __all__ attribute is ignored
+# c.IPCompleter.limit_to__all__ = False
+
+# Instruct the completer to omit private method names
+# 
+# Specifically, when completing on ``object.<tab>``.
+# 
+# When 2 [default]: all names that start with '_' will be excluded.
+# 
+# When 1: all 'magic' names (``__foo__``) will be excluded.
+# 
+# When 0: nothing will be excluded.
+# c.IPCompleter.omit__names = 2
+
+#------------------------------------------------------------------------------
+# ScriptMagics configuration
+#------------------------------------------------------------------------------
+
+# Magics for talking to scripts
+# 
+# This defines a base `%%script` cell magic for running a cell with a program in
+# a subprocess, and registers a few top-level magics that call %%script with
+# common interpreters.
+
+# Extra script cell magics to define
+# 
+# This generates simple wrappers of `%%script foo` as `%%foo`.
+# 
+# If you want to add script magics that aren't on your path, specify them in
+# script_paths
+# c.ScriptMagics.script_magics = []
+
+# Dict mapping short 'ruby' names to full paths, such as '/opt/secret/bin/ruby'
+# 
+# Only necessary for items in script_magics where the default path will not find
+# the right interpreter.
+# c.ScriptMagics.script_paths = {}
+
+#------------------------------------------------------------------------------
+# StoreMagics configuration
+#------------------------------------------------------------------------------
+
+# Lightweight persistence for python variables.
+# 
+# Provides the %store magic.
+
+# If True, any %store-d variables will be automatically restored when IPython
+# starts.
+# c.StoreMagics.autorestore = False

--- a/jupyter_core/tests/dotipython_empty/profile_default/ipython_console_config.py
+++ b/jupyter_core/tests/dotipython_empty/profile_default/ipython_console_config.py
@@ -1,0 +1,531 @@
+# Configuration file for ipython-console.
+
+c = get_config()
+
+#------------------------------------------------------------------------------
+# ZMQTerminalIPythonApp configuration
+#------------------------------------------------------------------------------
+
+# ZMQTerminalIPythonApp will inherit config from: TerminalIPythonApp,
+# BaseIPythonApplication, Application, InteractiveShellApp, IPythonConsoleApp,
+# ConnectionFileMixin
+
+# Should variables loaded at startup (by startup files, exec_lines, etc.) be
+# hidden from tools like %who?
+# c.ZMQTerminalIPythonApp.hide_initial_ns = True
+
+# set the heartbeat port [default: random]
+# c.ZMQTerminalIPythonApp.hb_port = 0
+
+# A list of dotted module names of IPython extensions to load.
+# c.ZMQTerminalIPythonApp.extensions = []
+
+# Execute the given command string.
+# c.ZMQTerminalIPythonApp.code_to_run = ''
+
+# Path to the ssh key to use for logging in to the ssh server.
+# c.ZMQTerminalIPythonApp.sshkey = ''
+
+# The date format used by logging formatters for %(asctime)s
+# c.ZMQTerminalIPythonApp.log_datefmt = '%Y-%m-%d %H:%M:%S'
+
+# set the control (ROUTER) port [default: random]
+# c.ZMQTerminalIPythonApp.control_port = 0
+
+# Reraise exceptions encountered loading IPython extensions?
+# c.ZMQTerminalIPythonApp.reraise_ipython_extension_failures = False
+
+# Set the log level by value or name.
+# c.ZMQTerminalIPythonApp.log_level = 30
+
+# Run the file referenced by the PYTHONSTARTUP environment variable at IPython
+# startup.
+# c.ZMQTerminalIPythonApp.exec_PYTHONSTARTUP = True
+
+# Pre-load matplotlib and numpy for interactive use, selecting a particular
+# matplotlib backend and loop integration.
+# c.ZMQTerminalIPythonApp.pylab = None
+
+# Run the module as a script.
+# c.ZMQTerminalIPythonApp.module_to_run = ''
+
+# Whether to display a banner upon starting IPython.
+# c.ZMQTerminalIPythonApp.display_banner = True
+
+# dotted module name of an IPython extension to load.
+# c.ZMQTerminalIPythonApp.extra_extension = ''
+
+# Create a massive crash report when IPython encounters what may be an internal
+# error.  The default is to append a short message to the usual traceback
+# c.ZMQTerminalIPythonApp.verbose_crash = False
+
+# Whether to overwrite existing config files when copying
+# c.ZMQTerminalIPythonApp.overwrite = False
+
+# The IPython profile to use.
+# c.ZMQTerminalIPythonApp.profile = 'default'
+
+# If a command or file is given via the command-line, e.g. 'ipython foo.py',
+# start an interactive shell after executing the file or command.
+# c.ZMQTerminalIPythonApp.force_interact = False
+
+# List of files to run at IPython startup.
+# c.ZMQTerminalIPythonApp.exec_files = []
+
+# Start IPython quickly by skipping the loading of config files.
+# c.ZMQTerminalIPythonApp.quick = False
+
+# The Logging format template
+# c.ZMQTerminalIPythonApp.log_format = '[%(name)s]%(highlevel)s %(message)s'
+
+# Whether to install the default config files into the profile dir. If a new
+# profile is being created, and IPython contains config files for that profile,
+# then they will be staged into the new directory.  Otherwise, default config
+# files will be automatically generated.
+# c.ZMQTerminalIPythonApp.copy_config_files = False
+
+# set the stdin (ROUTER) port [default: random]
+# c.ZMQTerminalIPythonApp.stdin_port = 0
+
+# Path to an extra config file to load.
+# 
+# If specified, load this config file in addition to any other IPython config.
+# c.ZMQTerminalIPythonApp.extra_config_file = ''
+
+# lines of code to run at IPython startup.
+# c.ZMQTerminalIPythonApp.exec_lines = []
+
+# Enable GUI event loop integration with any of ('glut', 'gtk', 'gtk3', 'osx',
+# 'pyglet', 'qt', 'qt5', 'tk', 'wx').
+# c.ZMQTerminalIPythonApp.gui = None
+
+# A file to be run
+# c.ZMQTerminalIPythonApp.file_to_run = ''
+
+# Configure matplotlib for interactive use with the default matplotlib backend.
+# c.ZMQTerminalIPythonApp.matplotlib = None
+
+# Suppress warning messages about legacy config files
+# c.ZMQTerminalIPythonApp.ignore_old_config = False
+
+# set the iopub (PUB) port [default: random]
+# c.ZMQTerminalIPythonApp.iopub_port = 0
+
+# 
+# c.ZMQTerminalIPythonApp.transport = 'tcp'
+
+# JSON file in which to store connection info [default: kernel-<pid>.json]
+# 
+# This file will contain the IP, ports, and authentication key needed to connect
+# clients to this kernel. By default, this file will be created in the security
+# dir of the current profile, but can be specified by absolute path.
+# c.ZMQTerminalIPythonApp.connection_file = ''
+
+# The name of the IPython directory. This directory is used for logging
+# configuration (through profiles), history storage, etc. The default is usually
+# $HOME/.ipython. This option can also be specified through the environment
+# variable IPYTHONDIR.
+# c.ZMQTerminalIPythonApp.ipython_dir = ''
+
+# The SSH server to use to connect to the kernel.
+# c.ZMQTerminalIPythonApp.sshserver = ''
+
+# Set to display confirmation dialog on exit. You can always use 'exit' or
+# 'quit', to force a direct exit without any confirmation.
+# c.ZMQTerminalIPythonApp.confirm_exit = True
+
+# set the shell (ROUTER) port [default: random]
+# c.ZMQTerminalIPythonApp.shell_port = 0
+
+# The name of the default kernel to start.
+# c.ZMQTerminalIPythonApp.kernel_name = 'python'
+
+# If true, IPython will populate the user namespace with numpy, pylab, etc. and
+# an ``import *`` is done from numpy and pylab, when using pylab mode.
+# 
+# When False, pylab mode should not import any names into the user namespace.
+# c.ZMQTerminalIPythonApp.pylab_import_all = True
+
+# Connect to an already running kernel
+# c.ZMQTerminalIPythonApp.existing = ''
+
+# Set the kernel's IP address [default localhost]. If the IP address is
+# something other than localhost, then Consoles on other machines will be able
+# to connect to the Kernel, so be careful!
+# c.ZMQTerminalIPythonApp.ip = ''
+
+#------------------------------------------------------------------------------
+# ZMQTerminalInteractiveShell configuration
+#------------------------------------------------------------------------------
+
+# A subclass of TerminalInteractiveShell that uses the 0MQ kernel
+
+# ZMQTerminalInteractiveShell will inherit config from:
+# TerminalInteractiveShell, InteractiveShell
+
+# 
+# c.ZMQTerminalInteractiveShell.history_length = 10000
+
+# auto editing of files with syntax errors.
+# c.ZMQTerminalInteractiveShell.autoedit_syntax = False
+
+# If True, anything that would be passed to the pager will be displayed as
+# regular output instead.
+# c.ZMQTerminalInteractiveShell.display_page = False
+
+# 
+# c.ZMQTerminalInteractiveShell.debug = False
+
+# 'all', 'last', 'last_expr' or 'none', specifying which nodes should be run
+# interactively (displaying output from expressions).
+# c.ZMQTerminalInteractiveShell.ast_node_interactivity = 'last_expr'
+
+# Start logging to the default log file in overwrite mode. Use `logappend` to
+# specify a log file to **append** logs to.
+# c.ZMQTerminalInteractiveShell.logstart = False
+
+# Set the size of the output cache.  The default is 1000, you can change it
+# permanently in your config file.  Setting it to 0 completely disables the
+# caching system, and the minimum value accepted is 20 (if you provide a value
+# less than 20, it is reset to 0 and a warning is issued).  This limit is
+# defined because otherwise you'll spend more time re-flushing a too small cache
+# than working
+# c.ZMQTerminalInteractiveShell.cache_size = 1000
+
+# The shell program to be used for paging.
+# c.ZMQTerminalInteractiveShell.pager = 'less'
+
+# The name of the logfile to use.
+# c.ZMQTerminalInteractiveShell.logfile = ''
+
+# Save multi-line entries as one entry in readline history
+# c.ZMQTerminalInteractiveShell.multiline_history = True
+
+# 
+# c.ZMQTerminalInteractiveShell.readline_remove_delims = '-/~'
+
+# Enable magic commands to be called without the leading %.
+# c.ZMQTerminalInteractiveShell.automagic = True
+
+# Prefix to add to outputs coming from clients other than this one.
+# 
+# Only relevant if include_other_output is True.
+# c.ZMQTerminalInteractiveShell.other_output_prefix = '[remote] '
+
+# 
+# c.ZMQTerminalInteractiveShell.readline_parse_and_bind = ['tab: complete', '"\\C-l": clear-screen', 'set show-all-if-ambiguous on', '"\\C-o": tab-insert', '"\\C-r": reverse-search-history', '"\\C-s": forward-search-history', '"\\C-p": history-search-backward', '"\\C-n": history-search-forward', '"\\e[A": history-search-backward', '"\\e[B": history-search-forward', '"\\C-k": kill-line', '"\\C-u": unix-line-discard']
+
+# Use colors for displaying information about objects. Because this information
+# is passed through a pager (like 'less'), and some pagers get confused with
+# color codes, this capability can be turned off.
+# c.ZMQTerminalInteractiveShell.color_info = True
+
+# Callable object called via 'callable' image handler with one argument, `data`,
+# which is `msg["content"]["data"]` where `msg` is the message from iopub
+# channel.  For exmaple, you can find base64 encoded PNG data as
+# `data['image/png']`.
+# c.ZMQTerminalInteractiveShell.callable_image_handler = None
+
+# Command to invoke an image viewer program when you are using 'stream' image
+# handler.  This option is a list of string where the first element is the
+# command itself and reminders are the options for the command.  Raw image data
+# is given as STDIN to the program.
+# c.ZMQTerminalInteractiveShell.stream_image_handler = []
+
+# 
+# c.ZMQTerminalInteractiveShell.separate_out2 = ''
+
+# Autoindent IPython code entered interactively.
+# c.ZMQTerminalInteractiveShell.autoindent = True
+
+# The part of the banner to be printed after the profile
+# c.ZMQTerminalInteractiveShell.banner2 = ''
+
+# Don't call post-execute functions that have failed in the past.
+# c.ZMQTerminalInteractiveShell.disable_failing_post_execute = False
+
+# Deprecated, use PromptManager.out_template
+# c.ZMQTerminalInteractiveShell.prompt_out = 'Out[\\#]: '
+
+# 
+# c.ZMQTerminalInteractiveShell.object_info_string_level = 0
+
+# 
+# c.ZMQTerminalInteractiveShell.separate_out = ''
+
+# Automatically call the pdb debugger after every exception.
+# c.ZMQTerminalInteractiveShell.pdb = False
+
+# Deprecated, use PromptManager.in_template
+# c.ZMQTerminalInteractiveShell.prompt_in1 = 'In [\\#]: '
+
+# 
+# c.ZMQTerminalInteractiveShell.separate_in = '\n'
+
+# 
+# c.ZMQTerminalInteractiveShell.wildcards_case_sensitive = True
+
+# Enable auto setting the terminal title.
+# c.ZMQTerminalInteractiveShell.term_title = False
+
+# Enable deep (recursive) reloading by default. IPython can use the deep_reload
+# module which reloads changes in modules recursively (it replaces the reload()
+# function, so you don't need to change anything to use it). deep_reload()
+# forces a full reload of modules whose code may have changed, which the default
+# reload() function does not.  When deep_reload is off, IPython will use the
+# normal reload(), but deep_reload will still be available as dreload().
+# c.ZMQTerminalInteractiveShell.deep_reload = False
+
+# Deprecated, use PromptManager.in2_template
+# c.ZMQTerminalInteractiveShell.prompt_in2 = '   .\\D.: '
+
+# Whether to include output from clients other than this one sharing the same
+# kernel.
+# 
+# Outputs are not displayed until enter is pressed.
+# c.ZMQTerminalInteractiveShell.include_other_output = False
+
+# Preferred object representation MIME type in order.  First matched MIME type
+# will be used.
+# c.ZMQTerminalInteractiveShell.mime_preference = ['image/png', 'image/jpeg', 'image/svg+xml']
+
+# 
+# c.ZMQTerminalInteractiveShell.readline_use = True
+
+# Make IPython automatically call any callable object even if you didn't type
+# explicit parentheses. For example, 'str 43' becomes 'str(43)' automatically.
+# The value can be '0' to disable the feature, '1' for 'smart' autocall, where
+# it is not applied if there are no more arguments on the line, and '2' for
+# 'full' autocall, where all callable objects are automatically called (even if
+# no arguments are present).
+# c.ZMQTerminalInteractiveShell.autocall = 0
+
+# The part of the banner to be printed before the profile
+# c.ZMQTerminalInteractiveShell.banner1 = 'Python 3.4.3 |Continuum Analytics, Inc.| (default, Mar  6 2015, 12:07:41) \nType "copyright", "credits" or "license" for more information.\n\nIPython 3.1.0 -- An enhanced Interactive Python.\nAnaconda is brought to you by Continuum Analytics.\nPlease check out: http://continuum.io/thanks and https://binstar.org\n?         -> Introduction and overview of IPython\'s features.\n%quickref -> Quick reference.\nhelp      -> Python\'s own help system.\nobject?   -> Details about \'object\', use \'object??\' for extra details.\n'
+
+# Handler for image type output.  This is useful, for example, when connecting
+# to the kernel in which pylab inline backend is activated.  There are four
+# handlers defined.  'PIL': Use Python Imaging Library to popup image; 'stream':
+# Use an external program to show the image.  Image will be fed into the STDIN
+# of the program.  You will need to configure `stream_image_handler`;
+# 'tempfile': Use an external program to show the image.  Image will be saved in
+# a temporally file and the program is called with the temporally file.  You
+# will need to configure `tempfile_image_handler`; 'callable': You can set any
+# Python callable which is called with the image data.  You will need to
+# configure `callable_image_handler`.
+# c.ZMQTerminalInteractiveShell.image_handler = None
+
+# Set the color scheme (NoColor, Linux, or LightBG).
+# c.ZMQTerminalInteractiveShell.colors = 'LightBG'
+
+# Set the editor used by IPython (default to $EDITOR/vi/notepad).
+# c.ZMQTerminalInteractiveShell.editor = 'mate -w'
+
+# Show rewritten input, e.g. for autocall.
+# c.ZMQTerminalInteractiveShell.show_rewritten_input = True
+
+# 
+# c.ZMQTerminalInteractiveShell.xmode = 'Context'
+
+# 
+# c.ZMQTerminalInteractiveShell.quiet = False
+
+# A list of ast.NodeTransformer subclass instances, which will be applied to
+# user input before code is run.
+# c.ZMQTerminalInteractiveShell.ast_transformers = []
+
+# 
+# c.ZMQTerminalInteractiveShell.ipython_dir = ''
+
+# Set to confirm when you try to exit IPython with an EOF (Control-D in Unix,
+# Control-Z/Enter in Windows). By typing 'exit' or 'quit', you can force a
+# direct exit without any confirmation.
+# c.ZMQTerminalInteractiveShell.confirm_exit = True
+
+# Deprecated, use PromptManager.justify
+# c.ZMQTerminalInteractiveShell.prompts_pad_left = True
+
+# Timeout for giving up on a kernel (in seconds).
+# 
+# On first connect and restart, the console tests whether the kernel is running
+# and responsive by sending kernel_info_requests. This sets the timeout in
+# seconds for how long the kernel can take before being presumed dead.
+# c.ZMQTerminalInteractiveShell.kernel_timeout = 60
+
+# Number of lines of your screen, used to control printing of very long strings.
+# Strings longer than this number of lines will be sent through a pager instead
+# of directly printed.  The default value for this is 0, which means IPython
+# will auto-detect your screen size every time it needs to print certain
+# potentially long strings (this doesn't change the behavior of the 'print'
+# keyword, it's only triggered internally). If for some reason this isn't
+# working well (it needs curses support), specify it yourself. Otherwise don't
+# change the default.
+# c.ZMQTerminalInteractiveShell.screen_length = 0
+
+# Start logging to the given file in append mode. Use `logfile` to specify a log
+# file to **overwrite** logs to.
+# c.ZMQTerminalInteractiveShell.logappend = ''
+
+# Command to invoke an image viewer program when you are using 'tempfile' image
+# handler.  This option is a list of string where the first element is the
+# command itself and reminders are the options for the command.  You can use
+# {file} and {format} in the string to represent the location of the generated
+# image file and image format.
+# c.ZMQTerminalInteractiveShell.tempfile_image_handler = []
+
+#------------------------------------------------------------------------------
+# KernelManager configuration
+#------------------------------------------------------------------------------
+
+# Manages a single kernel in a subprocess on this host.
+# 
+# This version starts kernels with Popen.
+
+# KernelManager will inherit config from: ConnectionFileMixin
+
+# set the heartbeat port [default: random]
+# c.KernelManager.hb_port = 0
+
+# set the stdin (ROUTER) port [default: random]
+# c.KernelManager.stdin_port = 0
+
+# 
+# c.KernelManager.transport = 'tcp'
+
+# JSON file in which to store connection info [default: kernel-<pid>.json]
+# 
+# This file will contain the IP, ports, and authentication key needed to connect
+# clients to this kernel. By default, this file will be created in the security
+# dir of the current profile, but can be specified by absolute path.
+# c.KernelManager.connection_file = ''
+
+# set the control (ROUTER) port [default: random]
+# c.KernelManager.control_port = 0
+
+# set the shell (ROUTER) port [default: random]
+# c.KernelManager.shell_port = 0
+
+# Should we autorestart the kernel if it dies.
+# c.KernelManager.autorestart = False
+
+# DEPRECATED: Use kernel_name instead.
+# 
+# The Popen Command to launch the kernel. Override this if you have a custom
+# kernel. If kernel_cmd is specified in a configuration file, IPython does not
+# pass any arguments to the kernel, because it cannot make any assumptions about
+# the  arguments that the kernel understands. In particular, this means that the
+# kernel does not receive the option --debug if it given on the IPython command
+# line.
+# c.KernelManager.kernel_cmd = []
+
+# Set the kernel's IP address [default localhost]. If the IP address is
+# something other than localhost, then Consoles on other machines will be able
+# to connect to the Kernel, so be careful!
+# c.KernelManager.ip = ''
+
+# set the iopub (PUB) port [default: random]
+# c.KernelManager.iopub_port = 0
+
+#------------------------------------------------------------------------------
+# ProfileDir configuration
+#------------------------------------------------------------------------------
+
+# An object to manage the profile directory and its resources.
+# 
+# The profile directory is used by all IPython applications, to manage
+# configuration, logging and security.
+# 
+# This object knows how to find, create and manage these directories. This
+# should be used by any code that wants to handle profiles.
+
+# Set the profile location directly. This overrides the logic used by the
+# `profile` option.
+# c.ProfileDir.location = ''
+
+#------------------------------------------------------------------------------
+# Session configuration
+#------------------------------------------------------------------------------
+
+# Object for handling serialization and sending of messages.
+# 
+# The Session object handles building messages and sending them with ZMQ sockets
+# or ZMQStream objects.  Objects can communicate with each other over the
+# network via Session objects, and only need to work with the dict-based IPython
+# message spec. The Session will handle serialization/deserialization, security,
+# and metadata.
+# 
+# Sessions support configurable serialization via packer/unpacker traits, and
+# signing with HMAC digests via the key/keyfile traits.
+# 
+# Parameters ----------
+# 
+# debug : bool
+#     whether to trigger extra debugging statements
+# packer/unpacker : str : 'json', 'pickle' or import_string
+#     importstrings for methods to serialize message parts.  If just
+#     'json' or 'pickle', predefined JSON and pickle packers will be used.
+#     Otherwise, the entire importstring must be used.
+# 
+#     The functions must accept at least valid JSON input, and output *bytes*.
+# 
+#     For example, to use msgpack:
+#     packer = 'msgpack.packb', unpacker='msgpack.unpackb'
+# pack/unpack : callables
+#     You can also set the pack/unpack callables for serialization directly.
+# session : bytes
+#     the ID of this Session object.  The default is to generate a new UUID.
+# username : unicode
+#     username added to message headers.  The default is to ask the OS.
+# key : bytes
+#     The key used to initialize an HMAC signature.  If unset, messages
+#     will not be signed or checked.
+# keyfile : filepath
+#     The file containing a key.  If this is set, `key` will be initialized
+#     to the contents of the file.
+
+# The digest scheme used to construct the message signatures. Must have the form
+# 'hmac-HASH'.
+# c.Session.signature_scheme = 'hmac-sha256'
+
+# The maximum number of digests to remember.
+# 
+# The digest history will be culled when it exceeds this value.
+# c.Session.digest_history_size = 65536
+
+# The name of the unpacker for unserializing messages. Only used with custom
+# functions for `packer`.
+# c.Session.unpacker = 'json'
+
+# The name of the packer for serializing messages. Should be one of 'json',
+# 'pickle', or an import name for a custom callable serializer.
+# c.Session.packer = 'json'
+
+# Username for the Session. Default is your system username.
+# c.Session.username = 'minrk'
+
+# Debug output in the Session
+# c.Session.debug = False
+
+# path to file containing execution key.
+# c.Session.keyfile = ''
+
+# The maximum number of items for a container to be introspected for custom
+# serialization. Containers larger than this are pickled outright.
+# c.Session.item_threshold = 64
+
+# Threshold (in bytes) beyond which an object's buffer should be extracted to
+# avoid pickling.
+# c.Session.buffer_threshold = 1024
+
+# The UUID identifying this session.
+# c.Session.session = ''
+
+# Threshold (in bytes) beyond which a buffer should be sent without copying.
+# c.Session.copy_threshold = 65536
+
+# execution key, for signing messages.
+# c.Session.key = b''
+
+# Metadata dictionary, which serves as the default top-level metadata dict for
+# each message.
+# c.Session.metadata = {}

--- a/jupyter_core/tests/dotipython_empty/profile_default/ipython_kernel_config.py
+++ b/jupyter_core/tests/dotipython_empty/profile_default/ipython_kernel_config.py
@@ -1,0 +1,408 @@
+# Configuration file for ipython-kernel.
+
+c = get_config()
+
+#------------------------------------------------------------------------------
+# IPKernelApp configuration
+#------------------------------------------------------------------------------
+
+# IPython: an enhanced interactive Python shell.
+
+# IPKernelApp will inherit config from: BaseIPythonApplication, Application,
+# InteractiveShellApp, ConnectionFileMixin
+
+# Should variables loaded at startup (by startup files, exec_lines, etc.) be
+# hidden from tools like %who?
+# c.IPKernelApp.hide_initial_ns = True
+
+# The importstring for the DisplayHook factory
+# c.IPKernelApp.displayhook_class = 'IPython.kernel.zmq.displayhook.ZMQDisplayHook'
+
+# A list of dotted module names of IPython extensions to load.
+# c.IPKernelApp.extensions = []
+
+# Execute the given command string.
+# c.IPKernelApp.code_to_run = ''
+
+# redirect stderr to the null device
+# c.IPKernelApp.no_stderr = False
+
+# The date format used by logging formatters for %(asctime)s
+# c.IPKernelApp.log_datefmt = '%Y-%m-%d %H:%M:%S'
+
+# Whether to create profile dir if it doesn't exist
+# c.IPKernelApp.auto_create = False
+
+# Reraise exceptions encountered loading IPython extensions?
+# c.IPKernelApp.reraise_ipython_extension_failures = False
+
+# Set the log level by value or name.
+# c.IPKernelApp.log_level = 30
+
+# Run the file referenced by the PYTHONSTARTUP environment variable at IPython
+# startup.
+# c.IPKernelApp.exec_PYTHONSTARTUP = True
+
+# Pre-load matplotlib and numpy for interactive use, selecting a particular
+# matplotlib backend and loop integration.
+# c.IPKernelApp.pylab = None
+
+# Run the module as a script.
+# c.IPKernelApp.module_to_run = ''
+
+# The importstring for the OutStream factory
+# c.IPKernelApp.outstream_class = 'IPython.kernel.zmq.iostream.OutStream'
+
+# dotted module name of an IPython extension to load.
+# c.IPKernelApp.extra_extension = ''
+
+# Create a massive crash report when IPython encounters what may be an internal
+# error.  The default is to append a short message to the usual traceback
+# c.IPKernelApp.verbose_crash = False
+
+# Whether to overwrite existing config files when copying
+# c.IPKernelApp.overwrite = False
+
+# The IPython profile to use.
+# c.IPKernelApp.profile = 'default'
+
+# List of files to run at IPython startup.
+# c.IPKernelApp.exec_files = []
+
+# The Logging format template
+# c.IPKernelApp.log_format = '[%(name)s]%(highlevel)s %(message)s'
+
+# Whether to install the default config files into the profile dir. If a new
+# profile is being created, and IPython contains config files for that profile,
+# then they will be staged into the new directory.  Otherwise, default config
+# files will be automatically generated.
+# c.IPKernelApp.copy_config_files = False
+
+# set the stdin (ROUTER) port [default: random]
+# c.IPKernelApp.stdin_port = 0
+
+# Path to an extra config file to load.
+# 
+# If specified, load this config file in addition to any other IPython config.
+# c.IPKernelApp.extra_config_file = ''
+
+# lines of code to run at IPython startup.
+# c.IPKernelApp.exec_lines = []
+
+# set the control (ROUTER) port [default: random]
+# c.IPKernelApp.control_port = 0
+
+# set the heartbeat port [default: random]
+# c.IPKernelApp.hb_port = 0
+
+# Enable GUI event loop integration with any of ('glut', 'gtk', 'gtk3', 'osx',
+# 'pyglet', 'qt', 'qt5', 'tk', 'wx').
+# c.IPKernelApp.gui = None
+
+# A file to be run
+# c.IPKernelApp.file_to_run = ''
+
+# The name of the IPython directory. This directory is used for logging
+# configuration (through profiles), history storage, etc. The default is usually
+# $HOME/.ipython. This option can also be specified through the environment
+# variable IPYTHONDIR.
+# c.IPKernelApp.ipython_dir = ''
+
+# kill this process if its parent dies.  On Windows, the argument specifies the
+# HANDLE of the parent process, otherwise it is simply boolean.
+# c.IPKernelApp.parent_handle = 0
+
+# Configure matplotlib for interactive use with the default matplotlib backend.
+# c.IPKernelApp.matplotlib = None
+
+# set the iopub (PUB) port [default: random]
+# c.IPKernelApp.iopub_port = 0
+
+# redirect stdout to the null device
+# c.IPKernelApp.no_stdout = False
+
+# 
+# c.IPKernelApp.transport = 'tcp'
+
+# JSON file in which to store connection info [default: kernel-<pid>.json]
+# 
+# This file will contain the IP, ports, and authentication key needed to connect
+# clients to this kernel. By default, this file will be created in the security
+# dir of the current profile, but can be specified by absolute path.
+# c.IPKernelApp.connection_file = ''
+
+# The Kernel subclass to be used.
+# 
+# This should allow easy re-use of the IPKernelApp entry point to configure and
+# launch kernels other than IPython's own.
+# c.IPKernelApp.kernel_class = <class 'IPython.kernel.zmq.ipkernel.IPythonKernel'>
+
+# ONLY USED ON WINDOWS Interrupt this process when the parent is signaled.
+# c.IPKernelApp.interrupt = 0
+
+# set the shell (ROUTER) port [default: random]
+# c.IPKernelApp.shell_port = 0
+
+# If true, IPython will populate the user namespace with numpy, pylab, etc. and
+# an ``import *`` is done from numpy and pylab, when using pylab mode.
+# 
+# When False, pylab mode should not import any names into the user namespace.
+# c.IPKernelApp.pylab_import_all = True
+
+# Set the kernel's IP address [default localhost]. If the IP address is
+# something other than localhost, then Consoles on other machines will be able
+# to connect to the Kernel, so be careful!
+# c.IPKernelApp.ip = ''
+
+#------------------------------------------------------------------------------
+# IPythonKernel configuration
+#------------------------------------------------------------------------------
+
+# IPythonKernel will inherit config from: Kernel
+
+# 
+# c.IPythonKernel._execute_sleep = 0.0005
+
+# Whether to use appnope for compatiblity with OS X App Nap.
+# 
+# Only affects OS X >= 10.9.
+# c.IPythonKernel._darwin_app_nap = True
+
+# 
+# c.IPythonKernel._poll_interval = 0.05
+
+#------------------------------------------------------------------------------
+# ZMQInteractiveShell configuration
+#------------------------------------------------------------------------------
+
+# A subclass of InteractiveShell for ZMQ.
+
+# ZMQInteractiveShell will inherit config from: InteractiveShell
+
+# 
+# c.ZMQInteractiveShell.object_info_string_level = 0
+
+# 
+# c.ZMQInteractiveShell.separate_out = ''
+
+# Automatically call the pdb debugger after every exception.
+# c.ZMQInteractiveShell.pdb = False
+
+# 
+# c.ZMQInteractiveShell.ipython_dir = ''
+
+# 
+# c.ZMQInteractiveShell.history_length = 10000
+
+# 
+# c.ZMQInteractiveShell.readline_remove_delims = '-/~'
+
+# If True, anything that would be passed to the pager will be displayed as
+# regular output instead.
+# c.ZMQInteractiveShell.display_page = False
+
+# Deprecated, use PromptManager.in2_template
+# c.ZMQInteractiveShell.prompt_in2 = '   .\\D.: '
+
+# 
+# c.ZMQInteractiveShell.separate_in = '\n'
+
+# Start logging to the default log file in overwrite mode. Use `logappend` to
+# specify a log file to **append** logs to.
+# c.ZMQInteractiveShell.logstart = False
+
+# Set the size of the output cache.  The default is 1000, you can change it
+# permanently in your config file.  Setting it to 0 completely disables the
+# caching system, and the minimum value accepted is 20 (if you provide a value
+# less than 20, it is reset to 0 and a warning is issued).  This limit is
+# defined because otherwise you'll spend more time re-flushing a too small cache
+# than working
+# c.ZMQInteractiveShell.cache_size = 1000
+
+# 
+# c.ZMQInteractiveShell.wildcards_case_sensitive = True
+
+# The name of the logfile to use.
+# c.ZMQInteractiveShell.logfile = ''
+
+# 'all', 'last', 'last_expr' or 'none', specifying which nodes should be run
+# interactively (displaying output from expressions).
+# c.ZMQInteractiveShell.ast_node_interactivity = 'last_expr'
+
+# 
+# c.ZMQInteractiveShell.debug = False
+
+# 
+# c.ZMQInteractiveShell.quiet = False
+
+# Save multi-line entries as one entry in readline history
+# c.ZMQInteractiveShell.multiline_history = True
+
+# Deprecated, use PromptManager.in_template
+# c.ZMQInteractiveShell.prompt_in1 = 'In [\\#]: '
+
+# Enable magic commands to be called without the leading %.
+# c.ZMQInteractiveShell.automagic = True
+
+# The part of the banner to be printed before the profile
+# c.ZMQInteractiveShell.banner1 = 'Python 3.4.3 |Continuum Analytics, Inc.| (default, Mar  6 2015, 12:07:41) \nType "copyright", "credits" or "license" for more information.\n\nIPython 3.1.0 -- An enhanced Interactive Python.\nAnaconda is brought to you by Continuum Analytics.\nPlease check out: http://continuum.io/thanks and https://binstar.org\n?         -> Introduction and overview of IPython\'s features.\n%quickref -> Quick reference.\nhelp      -> Python\'s own help system.\nobject?   -> Details about \'object\', use \'object??\' for extra details.\n'
+
+# Make IPython automatically call any callable object even if you didn't type
+# explicit parentheses. For example, 'str 43' becomes 'str(43)' automatically.
+# The value can be '0' to disable the feature, '1' for 'smart' autocall, where
+# it is not applied if there are no more arguments on the line, and '2' for
+# 'full' autocall, where all callable objects are automatically called (even if
+# no arguments are present).
+# c.ZMQInteractiveShell.autocall = 0
+
+# 
+# c.ZMQInteractiveShell.readline_parse_and_bind = ['tab: complete', '"\\C-l": clear-screen', 'set show-all-if-ambiguous on', '"\\C-o": tab-insert', '"\\C-r": reverse-search-history', '"\\C-s": forward-search-history', '"\\C-p": history-search-backward', '"\\C-n": history-search-forward', '"\\e[A": history-search-backward', '"\\e[B": history-search-forward', '"\\C-k": kill-line', '"\\C-u": unix-line-discard']
+
+# Set the color scheme (NoColor, Linux, or LightBG).
+# c.ZMQInteractiveShell.colors = 'LightBG'
+
+# Use colors for displaying information about objects. Because this information
+# is passed through a pager (like 'less'), and some pagers get confused with
+# color codes, this capability can be turned off.
+# c.ZMQInteractiveShell.color_info = True
+
+# Show rewritten input, e.g. for autocall.
+# c.ZMQInteractiveShell.show_rewritten_input = True
+
+# 
+# c.ZMQInteractiveShell.xmode = 'Context'
+
+# 
+# c.ZMQInteractiveShell.separate_out2 = ''
+
+# The part of the banner to be printed after the profile
+# c.ZMQInteractiveShell.banner2 = ''
+
+# Start logging to the given file in append mode. Use `logfile` to specify a log
+# file to **overwrite** logs to.
+# c.ZMQInteractiveShell.logappend = ''
+
+# Don't call post-execute functions that have failed in the past.
+# c.ZMQInteractiveShell.disable_failing_post_execute = False
+
+# Deprecated, use PromptManager.out_template
+# c.ZMQInteractiveShell.prompt_out = 'Out[\\#]: '
+
+# Enable deep (recursive) reloading by default. IPython can use the deep_reload
+# module which reloads changes in modules recursively (it replaces the reload()
+# function, so you don't need to change anything to use it). deep_reload()
+# forces a full reload of modules whose code may have changed, which the default
+# reload() function does not.  When deep_reload is off, IPython will use the
+# normal reload(), but deep_reload will still be available as dreload().
+# c.ZMQInteractiveShell.deep_reload = False
+
+# Deprecated, use PromptManager.justify
+# c.ZMQInteractiveShell.prompts_pad_left = True
+
+# A list of ast.NodeTransformer subclass instances, which will be applied to
+# user input before code is run.
+# c.ZMQInteractiveShell.ast_transformers = []
+
+#------------------------------------------------------------------------------
+# ProfileDir configuration
+#------------------------------------------------------------------------------
+
+# An object to manage the profile directory and its resources.
+# 
+# The profile directory is used by all IPython applications, to manage
+# configuration, logging and security.
+# 
+# This object knows how to find, create and manage these directories. This
+# should be used by any code that wants to handle profiles.
+
+# Set the profile location directly. This overrides the logic used by the
+# `profile` option.
+# c.ProfileDir.location = ''
+
+#------------------------------------------------------------------------------
+# Session configuration
+#------------------------------------------------------------------------------
+
+# Object for handling serialization and sending of messages.
+# 
+# The Session object handles building messages and sending them with ZMQ sockets
+# or ZMQStream objects.  Objects can communicate with each other over the
+# network via Session objects, and only need to work with the dict-based IPython
+# message spec. The Session will handle serialization/deserialization, security,
+# and metadata.
+# 
+# Sessions support configurable serialization via packer/unpacker traits, and
+# signing with HMAC digests via the key/keyfile traits.
+# 
+# Parameters ----------
+# 
+# debug : bool
+#     whether to trigger extra debugging statements
+# packer/unpacker : str : 'json', 'pickle' or import_string
+#     importstrings for methods to serialize message parts.  If just
+#     'json' or 'pickle', predefined JSON and pickle packers will be used.
+#     Otherwise, the entire importstring must be used.
+# 
+#     The functions must accept at least valid JSON input, and output *bytes*.
+# 
+#     For example, to use msgpack:
+#     packer = 'msgpack.packb', unpacker='msgpack.unpackb'
+# pack/unpack : callables
+#     You can also set the pack/unpack callables for serialization directly.
+# session : bytes
+#     the ID of this Session object.  The default is to generate a new UUID.
+# username : unicode
+#     username added to message headers.  The default is to ask the OS.
+# key : bytes
+#     The key used to initialize an HMAC signature.  If unset, messages
+#     will not be signed or checked.
+# keyfile : filepath
+#     The file containing a key.  If this is set, `key` will be initialized
+#     to the contents of the file.
+
+# The digest scheme used to construct the message signatures. Must have the form
+# 'hmac-HASH'.
+# c.Session.signature_scheme = 'hmac-sha256'
+
+# The maximum number of digests to remember.
+# 
+# The digest history will be culled when it exceeds this value.
+# c.Session.digest_history_size = 65536
+
+# The name of the unpacker for unserializing messages. Only used with custom
+# functions for `packer`.
+# c.Session.unpacker = 'json'
+
+# The name of the packer for serializing messages. Should be one of 'json',
+# 'pickle', or an import name for a custom callable serializer.
+# c.Session.packer = 'json'
+
+# Username for the Session. Default is your system username.
+# c.Session.username = 'minrk'
+
+# Debug output in the Session
+# c.Session.debug = False
+
+# path to file containing execution key.
+# c.Session.keyfile = ''
+
+# The maximum number of items for a container to be introspected for custom
+# serialization. Containers larger than this are pickled outright.
+# c.Session.item_threshold = 64
+
+# Threshold (in bytes) beyond which an object's buffer should be extracted to
+# avoid pickling.
+# c.Session.buffer_threshold = 1024
+
+# The UUID identifying this session.
+# c.Session.session = ''
+
+# Threshold (in bytes) beyond which a buffer should be sent without copying.
+# c.Session.copy_threshold = 65536
+
+# execution key, for signing messages.
+# c.Session.key = b''
+
+# Metadata dictionary, which serves as the default top-level metadata dict for
+# each message.
+# c.Session.metadata = {}

--- a/jupyter_core/tests/dotipython_empty/profile_default/ipython_nbconvert_config.py
+++ b/jupyter_core/tests/dotipython_empty/profile_default/ipython_nbconvert_config.py
@@ -1,0 +1,971 @@
+# Configuration file for ipython-nbconvert.
+
+c = get_config()
+
+#------------------------------------------------------------------------------
+# NbConvertApp configuration
+#------------------------------------------------------------------------------
+
+# This application is used to convert notebook files (*.ipynb) to various other
+# formats.
+# 
+# WARNING: THE COMMANDLINE INTERFACE MAY CHANGE IN FUTURE RELEASES.
+
+# NbConvertApp will inherit config from: BaseIPythonApplication, Application
+
+# List of notebooks to convert. Wildcards are supported. Filenames passed
+# positionally will be added to the list.
+# c.NbConvertApp.notebooks = []
+
+# The IPython profile to use.
+# c.NbConvertApp.profile = 'default'
+
+# The export format to be used.
+# c.NbConvertApp.export_format = 'html'
+
+# The date format used by logging formatters for %(asctime)s
+# c.NbConvertApp.log_datefmt = '%Y-%m-%d %H:%M:%S'
+
+# overwrite base name use for output files. can only be used when converting one
+# notebook at a time.
+# c.NbConvertApp.output_base = ''
+
+# Create a massive crash report when IPython encounters what may be an internal
+# error.  The default is to append a short message to the usual traceback
+# c.NbConvertApp.verbose_crash = False
+
+# Path to an extra config file to load.
+# 
+# If specified, load this config file in addition to any other IPython config.
+# c.NbConvertApp.extra_config_file = ''
+
+# Writer class used to write the  results of the conversion
+# c.NbConvertApp.writer_class = 'FilesWriter'
+
+# PostProcessor class used to write the  results of the conversion
+# c.NbConvertApp.postprocessor_class = ''
+
+# Set the log level by value or name.
+# c.NbConvertApp.log_level = 30
+
+# The name of the IPython directory. This directory is used for logging
+# configuration (through profiles), history storage, etc. The default is usually
+# $HOME/.ipython. This option can also be specified through the environment
+# variable IPYTHONDIR.
+# c.NbConvertApp.ipython_dir = ''
+
+# Whether to create profile dir if it doesn't exist
+# c.NbConvertApp.auto_create = False
+
+# Whether to overwrite existing config files when copying
+# c.NbConvertApp.overwrite = False
+
+# Whether to apply a suffix prior to the extension (only relevant when
+# converting to notebook format). The suffix is determined by the exporter, and
+# is usually '.nbconvert'.
+# c.NbConvertApp.use_output_suffix = True
+
+# The Logging format template
+# c.NbConvertApp.log_format = '[%(name)s]%(highlevel)s %(message)s'
+
+# Whether to install the default config files into the profile dir. If a new
+# profile is being created, and IPython contains config files for that profile,
+# then they will be staged into the new directory.  Otherwise, default config
+# files will be automatically generated.
+# c.NbConvertApp.copy_config_files = False
+
+#------------------------------------------------------------------------------
+# NbConvertBase configuration
+#------------------------------------------------------------------------------
+
+# Global configurable class for shared config
+# 
+# Useful for display data priority that might be use by many transformers
+
+# DEPRECATED default highlight language, please use language_info metadata
+# instead
+# c.NbConvertBase.default_language = 'ipython'
+
+# An ordered list of preferred output type, the first encountered will usually
+# be used when converting discarding the others.
+# c.NbConvertBase.display_data_priority = ['text/html', 'application/pdf', 'text/latex', 'image/svg+xml', 'image/png', 'image/jpeg', 'text/plain']
+
+#------------------------------------------------------------------------------
+# ProfileDir configuration
+#------------------------------------------------------------------------------
+
+# An object to manage the profile directory and its resources.
+# 
+# The profile directory is used by all IPython applications, to manage
+# configuration, logging and security.
+# 
+# This object knows how to find, create and manage these directories. This
+# should be used by any code that wants to handle profiles.
+
+# Set the profile location directly. This overrides the logic used by the
+# `profile` option.
+# c.ProfileDir.location = ''
+
+#------------------------------------------------------------------------------
+# Exporter configuration
+#------------------------------------------------------------------------------
+
+# Class containing methods that sequentially run a list of preprocessors on a
+# NotebookNode object and then return the modified NotebookNode object and
+# accompanying resources dict.
+
+# List of preprocessors, by name or namespace, to enable.
+# c.Exporter.preprocessors = []
+
+# List of preprocessors available by default, by name, namespace,  instance, or
+# type.
+# c.Exporter.default_preprocessors = ['IPython.nbconvert.preprocessors.coalesce_streams', 'IPython.nbconvert.preprocessors.SVG2PDFPreprocessor', 'IPython.nbconvert.preprocessors.ExtractOutputPreprocessor', 'IPython.nbconvert.preprocessors.CSSHTMLHeaderPreprocessor', 'IPython.nbconvert.preprocessors.RevealHelpPreprocessor', 'IPython.nbconvert.preprocessors.LatexPreprocessor', 'IPython.nbconvert.preprocessors.ClearOutputPreprocessor', 'IPython.nbconvert.preprocessors.ExecutePreprocessor', 'IPython.nbconvert.preprocessors.HighlightMagicsPreprocessor']
+
+# Extension of the file that should be written to disk
+# c.Exporter.file_extension = '.txt'
+
+#------------------------------------------------------------------------------
+# HTMLExporter configuration
+#------------------------------------------------------------------------------
+
+# Exports a basic HTML document.  This exporter assists with the export of HTML.
+# Inherit from it if you are writing your own HTML template and need custom
+# preprocessors/filters.  If you don't need custom preprocessors/ filters, just
+# change the 'template_file' config option.
+
+# HTMLExporter will inherit config from: TemplateExporter, Exporter
+
+# 
+# c.HTMLExporter.jinja_logic_block_end = ''
+
+# List of preprocessors available by default, by name, namespace,  instance, or
+# type.
+# c.HTMLExporter.default_preprocessors = ['IPython.nbconvert.preprocessors.coalesce_streams', 'IPython.nbconvert.preprocessors.SVG2PDFPreprocessor', 'IPython.nbconvert.preprocessors.ExtractOutputPreprocessor', 'IPython.nbconvert.preprocessors.CSSHTMLHeaderPreprocessor', 'IPython.nbconvert.preprocessors.RevealHelpPreprocessor', 'IPython.nbconvert.preprocessors.LatexPreprocessor', 'IPython.nbconvert.preprocessors.ClearOutputPreprocessor', 'IPython.nbconvert.preprocessors.ExecutePreprocessor', 'IPython.nbconvert.preprocessors.HighlightMagicsPreprocessor']
+
+# 
+# c.HTMLExporter.jinja_comment_block_start = ''
+
+# Dictionary of filters, by name and namespace, to add to the Jinja environment.
+# c.HTMLExporter.filters = {}
+
+# List of preprocessors, by name or namespace, to enable.
+# c.HTMLExporter.preprocessors = []
+
+# Name of the template file to use
+# c.HTMLExporter.template_file = 'default'
+
+# 
+# c.HTMLExporter.template_extension = '.tpl'
+
+# 
+# c.HTMLExporter.jinja_logic_block_start = ''
+
+# 
+# c.HTMLExporter.jinja_variable_block_start = ''
+
+# 
+# c.HTMLExporter.template_path = ['.']
+
+# 
+# c.HTMLExporter.jinja_comment_block_end = ''
+
+# 
+# c.HTMLExporter.jinja_variable_block_end = ''
+
+# Extension of the file that should be written to disk
+# c.HTMLExporter.file_extension = '.txt'
+
+# formats of raw cells to be included in this Exporter's output.
+# c.HTMLExporter.raw_mimetypes = []
+
+#------------------------------------------------------------------------------
+# LatexExporter configuration
+#------------------------------------------------------------------------------
+
+# Exports to a Latex template.  Inherit from this class if your template is
+# LaTeX based and you need custom tranformers/filters.  Inherit from it if  you
+# are writing your own HTML template and need custom tranformers/filters.   If
+# you don't need custom tranformers/filters, just change the  'template_file'
+# config option.  Place your template in the special "/latex"  subfolder of the
+# "../templates" folder.
+
+# LatexExporter will inherit config from: TemplateExporter, Exporter
+
+# 
+# c.LatexExporter.jinja_logic_block_end = '*))'
+
+# List of preprocessors available by default, by name, namespace,  instance, or
+# type.
+# c.LatexExporter.default_preprocessors = ['IPython.nbconvert.preprocessors.coalesce_streams', 'IPython.nbconvert.preprocessors.SVG2PDFPreprocessor', 'IPython.nbconvert.preprocessors.ExtractOutputPreprocessor', 'IPython.nbconvert.preprocessors.CSSHTMLHeaderPreprocessor', 'IPython.nbconvert.preprocessors.RevealHelpPreprocessor', 'IPython.nbconvert.preprocessors.LatexPreprocessor', 'IPython.nbconvert.preprocessors.ClearOutputPreprocessor', 'IPython.nbconvert.preprocessors.ExecutePreprocessor', 'IPython.nbconvert.preprocessors.HighlightMagicsPreprocessor']
+
+# 
+# c.LatexExporter.jinja_comment_block_start = '((='
+
+# Dictionary of filters, by name and namespace, to add to the Jinja environment.
+# c.LatexExporter.filters = {}
+
+# List of preprocessors, by name or namespace, to enable.
+# c.LatexExporter.preprocessors = []
+
+# Name of the template file to use
+# c.LatexExporter.template_file = 'default'
+
+# 
+# c.LatexExporter.template_extension = '.tplx'
+
+# 
+# c.LatexExporter.jinja_logic_block_start = '((*'
+
+# 
+# c.LatexExporter.jinja_variable_block_start = '((('
+
+# 
+# c.LatexExporter.template_path = ['.']
+
+# 
+# c.LatexExporter.jinja_comment_block_end = '=))'
+
+# 
+# c.LatexExporter.jinja_variable_block_end = ')))'
+
+# Extension of the file that should be written to disk
+# c.LatexExporter.file_extension = '.txt'
+
+# formats of raw cells to be included in this Exporter's output.
+# c.LatexExporter.raw_mimetypes = []
+
+#------------------------------------------------------------------------------
+# MarkdownExporter configuration
+#------------------------------------------------------------------------------
+
+# Exports to a markdown document (.md)
+
+# MarkdownExporter will inherit config from: TemplateExporter, Exporter
+
+# 
+# c.MarkdownExporter.jinja_logic_block_end = ''
+
+# List of preprocessors available by default, by name, namespace,  instance, or
+# type.
+# c.MarkdownExporter.default_preprocessors = ['IPython.nbconvert.preprocessors.coalesce_streams', 'IPython.nbconvert.preprocessors.SVG2PDFPreprocessor', 'IPython.nbconvert.preprocessors.ExtractOutputPreprocessor', 'IPython.nbconvert.preprocessors.CSSHTMLHeaderPreprocessor', 'IPython.nbconvert.preprocessors.RevealHelpPreprocessor', 'IPython.nbconvert.preprocessors.LatexPreprocessor', 'IPython.nbconvert.preprocessors.ClearOutputPreprocessor', 'IPython.nbconvert.preprocessors.ExecutePreprocessor', 'IPython.nbconvert.preprocessors.HighlightMagicsPreprocessor']
+
+# 
+# c.MarkdownExporter.jinja_comment_block_start = ''
+
+# Dictionary of filters, by name and namespace, to add to the Jinja environment.
+# c.MarkdownExporter.filters = {}
+
+# List of preprocessors, by name or namespace, to enable.
+# c.MarkdownExporter.preprocessors = []
+
+# Name of the template file to use
+# c.MarkdownExporter.template_file = 'default'
+
+# 
+# c.MarkdownExporter.template_extension = '.tpl'
+
+# 
+# c.MarkdownExporter.jinja_logic_block_start = ''
+
+# 
+# c.MarkdownExporter.jinja_variable_block_start = ''
+
+# 
+# c.MarkdownExporter.template_path = ['.']
+
+# 
+# c.MarkdownExporter.jinja_comment_block_end = ''
+
+# 
+# c.MarkdownExporter.jinja_variable_block_end = ''
+
+# Extension of the file that should be written to disk
+# c.MarkdownExporter.file_extension = '.txt'
+
+# formats of raw cells to be included in this Exporter's output.
+# c.MarkdownExporter.raw_mimetypes = []
+
+#------------------------------------------------------------------------------
+# NotebookExporter configuration
+#------------------------------------------------------------------------------
+
+# Exports to an IPython notebook.
+
+# NotebookExporter will inherit config from: Exporter
+
+# List of preprocessors, by name or namespace, to enable.
+# c.NotebookExporter.preprocessors = []
+
+# List of preprocessors available by default, by name, namespace,  instance, or
+# type.
+# c.NotebookExporter.default_preprocessors = ['IPython.nbconvert.preprocessors.coalesce_streams', 'IPython.nbconvert.preprocessors.SVG2PDFPreprocessor', 'IPython.nbconvert.preprocessors.ExtractOutputPreprocessor', 'IPython.nbconvert.preprocessors.CSSHTMLHeaderPreprocessor', 'IPython.nbconvert.preprocessors.RevealHelpPreprocessor', 'IPython.nbconvert.preprocessors.LatexPreprocessor', 'IPython.nbconvert.preprocessors.ClearOutputPreprocessor', 'IPython.nbconvert.preprocessors.ExecutePreprocessor', 'IPython.nbconvert.preprocessors.HighlightMagicsPreprocessor']
+
+# Extension of the file that should be written to disk
+# c.NotebookExporter.file_extension = '.txt'
+
+# The nbformat version to write. Use this to downgrade notebooks.
+# c.NotebookExporter.nbformat_version = 4
+
+#------------------------------------------------------------------------------
+# PDFExporter configuration
+#------------------------------------------------------------------------------
+
+# Writer designed to write to PDF files
+
+# PDFExporter will inherit config from: LatexExporter, TemplateExporter,
+# Exporter
+
+# 
+# c.PDFExporter.jinja_logic_block_end = '*))'
+
+# How many times latex will be called.
+# c.PDFExporter.latex_count = 3
+
+# List of preprocessors available by default, by name, namespace,  instance, or
+# type.
+# c.PDFExporter.default_preprocessors = ['IPython.nbconvert.preprocessors.coalesce_streams', 'IPython.nbconvert.preprocessors.SVG2PDFPreprocessor', 'IPython.nbconvert.preprocessors.ExtractOutputPreprocessor', 'IPython.nbconvert.preprocessors.CSSHTMLHeaderPreprocessor', 'IPython.nbconvert.preprocessors.RevealHelpPreprocessor', 'IPython.nbconvert.preprocessors.LatexPreprocessor', 'IPython.nbconvert.preprocessors.ClearOutputPreprocessor', 'IPython.nbconvert.preprocessors.ExecutePreprocessor', 'IPython.nbconvert.preprocessors.HighlightMagicsPreprocessor']
+
+# 
+# c.PDFExporter.jinja_comment_block_start = '((='
+
+# Dictionary of filters, by name and namespace, to add to the Jinja environment.
+# c.PDFExporter.filters = {}
+
+# List of preprocessors, by name or namespace, to enable.
+# c.PDFExporter.preprocessors = []
+
+# Name of the template file to use
+# c.PDFExporter.template_file = 'default'
+
+# 
+# c.PDFExporter.template_extension = '.tplx'
+
+# Whether to display the output of latex commands.
+# c.PDFExporter.verbose = False
+
+# 
+# c.PDFExporter.jinja_logic_block_start = '((*'
+
+# Shell command used to compile latex.
+# c.PDFExporter.latex_command = ['pdflatex', '{filename}']
+
+# 
+# c.PDFExporter.jinja_variable_block_start = '((('
+
+# 
+# c.PDFExporter.template_path = ['.']
+
+# Shell command used to run bibtex.
+# c.PDFExporter.bib_command = ['bibtex', '{filename}']
+
+# 
+# c.PDFExporter.jinja_comment_block_end = '=))'
+
+# File extensions of temp files to remove after running.
+# c.PDFExporter.temp_file_exts = ['.aux', '.bbl', '.blg', '.idx', '.log', '.out']
+
+# 
+# c.PDFExporter.jinja_variable_block_end = ')))'
+
+# Extension of the file that should be written to disk
+# c.PDFExporter.file_extension = '.txt'
+
+# formats of raw cells to be included in this Exporter's output.
+# c.PDFExporter.raw_mimetypes = []
+
+#------------------------------------------------------------------------------
+# PythonExporter configuration
+#------------------------------------------------------------------------------
+
+# Exports a Python code file.
+
+# PythonExporter will inherit config from: TemplateExporter, Exporter
+
+# 
+# c.PythonExporter.jinja_logic_block_end = ''
+
+# List of preprocessors available by default, by name, namespace,  instance, or
+# type.
+# c.PythonExporter.default_preprocessors = ['IPython.nbconvert.preprocessors.coalesce_streams', 'IPython.nbconvert.preprocessors.SVG2PDFPreprocessor', 'IPython.nbconvert.preprocessors.ExtractOutputPreprocessor', 'IPython.nbconvert.preprocessors.CSSHTMLHeaderPreprocessor', 'IPython.nbconvert.preprocessors.RevealHelpPreprocessor', 'IPython.nbconvert.preprocessors.LatexPreprocessor', 'IPython.nbconvert.preprocessors.ClearOutputPreprocessor', 'IPython.nbconvert.preprocessors.ExecutePreprocessor', 'IPython.nbconvert.preprocessors.HighlightMagicsPreprocessor']
+
+# 
+# c.PythonExporter.jinja_comment_block_start = ''
+
+# Dictionary of filters, by name and namespace, to add to the Jinja environment.
+# c.PythonExporter.filters = {}
+
+# List of preprocessors, by name or namespace, to enable.
+# c.PythonExporter.preprocessors = []
+
+# Name of the template file to use
+# c.PythonExporter.template_file = 'default'
+
+# 
+# c.PythonExporter.template_extension = '.tpl'
+
+# 
+# c.PythonExporter.jinja_logic_block_start = ''
+
+# 
+# c.PythonExporter.jinja_variable_block_start = ''
+
+# 
+# c.PythonExporter.template_path = ['.']
+
+# 
+# c.PythonExporter.jinja_comment_block_end = ''
+
+# 
+# c.PythonExporter.jinja_variable_block_end = ''
+
+# Extension of the file that should be written to disk
+# c.PythonExporter.file_extension = '.txt'
+
+# formats of raw cells to be included in this Exporter's output.
+# c.PythonExporter.raw_mimetypes = []
+
+#------------------------------------------------------------------------------
+# RSTExporter configuration
+#------------------------------------------------------------------------------
+
+# Exports restructured text documents.
+
+# RSTExporter will inherit config from: TemplateExporter, Exporter
+
+# 
+# c.RSTExporter.jinja_logic_block_end = ''
+
+# List of preprocessors available by default, by name, namespace,  instance, or
+# type.
+# c.RSTExporter.default_preprocessors = ['IPython.nbconvert.preprocessors.coalesce_streams', 'IPython.nbconvert.preprocessors.SVG2PDFPreprocessor', 'IPython.nbconvert.preprocessors.ExtractOutputPreprocessor', 'IPython.nbconvert.preprocessors.CSSHTMLHeaderPreprocessor', 'IPython.nbconvert.preprocessors.RevealHelpPreprocessor', 'IPython.nbconvert.preprocessors.LatexPreprocessor', 'IPython.nbconvert.preprocessors.ClearOutputPreprocessor', 'IPython.nbconvert.preprocessors.ExecutePreprocessor', 'IPython.nbconvert.preprocessors.HighlightMagicsPreprocessor']
+
+# 
+# c.RSTExporter.jinja_comment_block_start = ''
+
+# Dictionary of filters, by name and namespace, to add to the Jinja environment.
+# c.RSTExporter.filters = {}
+
+# List of preprocessors, by name or namespace, to enable.
+# c.RSTExporter.preprocessors = []
+
+# Name of the template file to use
+# c.RSTExporter.template_file = 'default'
+
+# 
+# c.RSTExporter.template_extension = '.tpl'
+
+# 
+# c.RSTExporter.jinja_logic_block_start = ''
+
+# 
+# c.RSTExporter.jinja_variable_block_start = ''
+
+# 
+# c.RSTExporter.template_path = ['.']
+
+# 
+# c.RSTExporter.jinja_comment_block_end = ''
+
+# 
+# c.RSTExporter.jinja_variable_block_end = ''
+
+# Extension of the file that should be written to disk
+# c.RSTExporter.file_extension = '.txt'
+
+# formats of raw cells to be included in this Exporter's output.
+# c.RSTExporter.raw_mimetypes = []
+
+#------------------------------------------------------------------------------
+# SlidesExporter configuration
+#------------------------------------------------------------------------------
+
+# Exports HTML slides with reveal.js
+
+# SlidesExporter will inherit config from: HTMLExporter, TemplateExporter,
+# Exporter
+
+# 
+# c.SlidesExporter.jinja_logic_block_end = ''
+
+# List of preprocessors available by default, by name, namespace,  instance, or
+# type.
+# c.SlidesExporter.default_preprocessors = ['IPython.nbconvert.preprocessors.coalesce_streams', 'IPython.nbconvert.preprocessors.SVG2PDFPreprocessor', 'IPython.nbconvert.preprocessors.ExtractOutputPreprocessor', 'IPython.nbconvert.preprocessors.CSSHTMLHeaderPreprocessor', 'IPython.nbconvert.preprocessors.RevealHelpPreprocessor', 'IPython.nbconvert.preprocessors.LatexPreprocessor', 'IPython.nbconvert.preprocessors.ClearOutputPreprocessor', 'IPython.nbconvert.preprocessors.ExecutePreprocessor', 'IPython.nbconvert.preprocessors.HighlightMagicsPreprocessor']
+
+# 
+# c.SlidesExporter.jinja_comment_block_start = ''
+
+# Dictionary of filters, by name and namespace, to add to the Jinja environment.
+# c.SlidesExporter.filters = {}
+
+# List of preprocessors, by name or namespace, to enable.
+# c.SlidesExporter.preprocessors = []
+
+# Name of the template file to use
+# c.SlidesExporter.template_file = 'default'
+
+# 
+# c.SlidesExporter.template_extension = '.tpl'
+
+# 
+# c.SlidesExporter.jinja_logic_block_start = ''
+
+# 
+# c.SlidesExporter.jinja_variable_block_start = ''
+
+# 
+# c.SlidesExporter.template_path = ['.']
+
+# 
+# c.SlidesExporter.jinja_comment_block_end = ''
+
+# 
+# c.SlidesExporter.jinja_variable_block_end = ''
+
+# Extension of the file that should be written to disk
+# c.SlidesExporter.file_extension = '.txt'
+
+# formats of raw cells to be included in this Exporter's output.
+# c.SlidesExporter.raw_mimetypes = []
+
+#------------------------------------------------------------------------------
+# TemplateExporter configuration
+#------------------------------------------------------------------------------
+
+# Exports notebooks into other file formats.  Uses Jinja 2 templating engine to
+# output new formats.  Inherit from this class if you are creating a new
+# template type along with new filters/preprocessors.  If the filters/
+# preprocessors provided by default suffice, there is no need to inherit from
+# this class.  Instead, override the template_file and file_extension traits via
+# a config file.
+# 
+# - ascii_only - add_prompts - add_anchor - html2text - strip_ansi -
+# comment_lines - ansi2html - strip_files_prefix - prevent_list_blocks -
+# highlight2html - indent - wrap_text - markdown2rst - citation2latex -
+# highlight2latex - filter_data_type - get_lines - escape_latex - ipython2python
+# - markdown2html - strip_dollars - path2url - posix_path - ansi2latex -
+# markdown2latex
+
+# TemplateExporter will inherit config from: Exporter
+
+# 
+# c.TemplateExporter.jinja_logic_block_end = ''
+
+# List of preprocessors available by default, by name, namespace,  instance, or
+# type.
+# c.TemplateExporter.default_preprocessors = ['IPython.nbconvert.preprocessors.coalesce_streams', 'IPython.nbconvert.preprocessors.SVG2PDFPreprocessor', 'IPython.nbconvert.preprocessors.ExtractOutputPreprocessor', 'IPython.nbconvert.preprocessors.CSSHTMLHeaderPreprocessor', 'IPython.nbconvert.preprocessors.RevealHelpPreprocessor', 'IPython.nbconvert.preprocessors.LatexPreprocessor', 'IPython.nbconvert.preprocessors.ClearOutputPreprocessor', 'IPython.nbconvert.preprocessors.ExecutePreprocessor', 'IPython.nbconvert.preprocessors.HighlightMagicsPreprocessor']
+
+# 
+# c.TemplateExporter.jinja_comment_block_start = ''
+
+# Dictionary of filters, by name and namespace, to add to the Jinja environment.
+# c.TemplateExporter.filters = {}
+
+# List of preprocessors, by name or namespace, to enable.
+# c.TemplateExporter.preprocessors = []
+
+# Name of the template file to use
+# c.TemplateExporter.template_file = 'default'
+
+# 
+# c.TemplateExporter.template_extension = '.tpl'
+
+# 
+# c.TemplateExporter.jinja_logic_block_start = ''
+
+# 
+# c.TemplateExporter.jinja_variable_block_start = ''
+
+# 
+# c.TemplateExporter.template_path = ['.']
+
+# 
+# c.TemplateExporter.jinja_comment_block_end = ''
+
+# 
+# c.TemplateExporter.jinja_variable_block_end = ''
+
+# Extension of the file that should be written to disk
+# c.TemplateExporter.file_extension = '.txt'
+
+# formats of raw cells to be included in this Exporter's output.
+# c.TemplateExporter.raw_mimetypes = []
+
+#------------------------------------------------------------------------------
+# CSSHTMLHeaderPreprocessor configuration
+#------------------------------------------------------------------------------
+
+# Preprocessor used to pre-process notebook for HTML output.  Adds IPython
+# notebook front-end CSS and Pygments CSS to HTML output.
+
+# CSSHTMLHeaderPreprocessor will inherit config from: Preprocessor,
+# NbConvertBase
+
+# CSS highlight class identifier
+# c.CSSHTMLHeaderPreprocessor.highlight_class = '.highlight'
+
+# 
+# c.CSSHTMLHeaderPreprocessor.enabled = False
+
+# DEPRECATED default highlight language, please use language_info metadata
+# instead
+# c.CSSHTMLHeaderPreprocessor.default_language = 'ipython'
+
+# An ordered list of preferred output type, the first encountered will usually
+# be used when converting discarding the others.
+# c.CSSHTMLHeaderPreprocessor.display_data_priority = ['text/html', 'application/pdf', 'text/latex', 'image/svg+xml', 'image/png', 'image/jpeg', 'text/plain']
+
+#------------------------------------------------------------------------------
+# ClearOutputPreprocessor configuration
+#------------------------------------------------------------------------------
+
+# Removes the output from all code cells in a notebook.
+
+# ClearOutputPreprocessor will inherit config from: Preprocessor, NbConvertBase
+
+# 
+# c.ClearOutputPreprocessor.enabled = False
+
+# DEPRECATED default highlight language, please use language_info metadata
+# instead
+# c.ClearOutputPreprocessor.default_language = 'ipython'
+
+# An ordered list of preferred output type, the first encountered will usually
+# be used when converting discarding the others.
+# c.ClearOutputPreprocessor.display_data_priority = ['text/html', 'application/pdf', 'text/latex', 'image/svg+xml', 'image/png', 'image/jpeg', 'text/plain']
+
+#------------------------------------------------------------------------------
+# ConvertFiguresPreprocessor configuration
+#------------------------------------------------------------------------------
+
+# Converts all of the outputs in a notebook from one format to another.
+
+# ConvertFiguresPreprocessor will inherit config from: Preprocessor,
+# NbConvertBase
+
+# Format the converter accepts
+# c.ConvertFiguresPreprocessor.from_format = ''
+
+# Format the converter writes
+# c.ConvertFiguresPreprocessor.to_format = ''
+
+# DEPRECATED default highlight language, please use language_info metadata
+# instead
+# c.ConvertFiguresPreprocessor.default_language = 'ipython'
+
+# 
+# c.ConvertFiguresPreprocessor.enabled = False
+
+# An ordered list of preferred output type, the first encountered will usually
+# be used when converting discarding the others.
+# c.ConvertFiguresPreprocessor.display_data_priority = ['text/html', 'application/pdf', 'text/latex', 'image/svg+xml', 'image/png', 'image/jpeg', 'text/plain']
+
+#------------------------------------------------------------------------------
+# ExecutePreprocessor configuration
+#------------------------------------------------------------------------------
+
+# Executes all the cells in a notebook
+
+# ExecutePreprocessor will inherit config from: Preprocessor, NbConvertBase
+
+# 
+# c.ExecutePreprocessor.enabled = False
+
+# DEPRECATED default highlight language, please use language_info metadata
+# instead
+# c.ExecutePreprocessor.default_language = 'ipython'
+
+# An ordered list of preferred output type, the first encountered will usually
+# be used when converting discarding the others.
+# c.ExecutePreprocessor.display_data_priority = ['text/html', 'application/pdf', 'text/latex', 'image/svg+xml', 'image/png', 'image/jpeg', 'text/plain']
+
+# If execution of a cell times out, interrupt the kernel and  continue executing
+# other cells rather than throwing an error and  stopping.
+# c.ExecutePreprocessor.interrupt_on_timeout = False
+
+# The time to wait (in seconds) for output from executions.
+# c.ExecutePreprocessor.timeout = 30
+
+#------------------------------------------------------------------------------
+# ExtractOutputPreprocessor configuration
+#------------------------------------------------------------------------------
+
+# Extracts all of the outputs from the notebook file.  The extracted  outputs
+# are returned in the 'resources' dictionary.
+
+# ExtractOutputPreprocessor will inherit config from: Preprocessor,
+# NbConvertBase
+
+# 
+# c.ExtractOutputPreprocessor.enabled = False
+
+# 
+# c.ExtractOutputPreprocessor.output_filename_template = '{unique_key}_{cell_index}_{index}{extension}'
+
+# DEPRECATED default highlight language, please use language_info metadata
+# instead
+# c.ExtractOutputPreprocessor.default_language = 'ipython'
+
+# 
+# c.ExtractOutputPreprocessor.extract_output_types = {'image/svg+xml', 'image/png', 'application/pdf', 'image/jpeg'}
+
+# An ordered list of preferred output type, the first encountered will usually
+# be used when converting discarding the others.
+# c.ExtractOutputPreprocessor.display_data_priority = ['text/html', 'application/pdf', 'text/latex', 'image/svg+xml', 'image/png', 'image/jpeg', 'text/plain']
+
+#------------------------------------------------------------------------------
+# HighlightMagicsPreprocessor configuration
+#------------------------------------------------------------------------------
+
+# Detects and tags code cells that use a different languages than Python.
+
+# HighlightMagicsPreprocessor will inherit config from: Preprocessor,
+# NbConvertBase
+
+# 
+# c.HighlightMagicsPreprocessor.enabled = False
+
+# Syntax highlighting for magic's extension languages. Each item associates a
+# language magic extension such as %%R, with a pygments lexer such as r.
+# c.HighlightMagicsPreprocessor.languages = {}
+
+# DEPRECATED default highlight language, please use language_info metadata
+# instead
+# c.HighlightMagicsPreprocessor.default_language = 'ipython'
+
+# An ordered list of preferred output type, the first encountered will usually
+# be used when converting discarding the others.
+# c.HighlightMagicsPreprocessor.display_data_priority = ['text/html', 'application/pdf', 'text/latex', 'image/svg+xml', 'image/png', 'image/jpeg', 'text/plain']
+
+#------------------------------------------------------------------------------
+# LatexPreprocessor configuration
+#------------------------------------------------------------------------------
+
+# Preprocessor for latex destined documents.
+# 
+# Mainly populates the `latex` key in the resources dict, adding definitions for
+# pygments highlight styles.
+
+# LatexPreprocessor will inherit config from: Preprocessor, NbConvertBase
+
+# 
+# c.LatexPreprocessor.enabled = False
+
+# DEPRECATED default highlight language, please use language_info metadata
+# instead
+# c.LatexPreprocessor.default_language = 'ipython'
+
+# An ordered list of preferred output type, the first encountered will usually
+# be used when converting discarding the others.
+# c.LatexPreprocessor.display_data_priority = ['text/html', 'application/pdf', 'text/latex', 'image/svg+xml', 'image/png', 'image/jpeg', 'text/plain']
+
+#------------------------------------------------------------------------------
+# Preprocessor configuration
+#------------------------------------------------------------------------------
+
+# A configurable preprocessor
+# 
+# Inherit from this class if you wish to have configurability for your
+# preprocessor.
+# 
+# Any configurable traitlets this class exposed will be configurable in profiles
+# using c.SubClassName.attribute = value
+# 
+# you can overwrite :meth:`preprocess_cell` to apply a transformation
+# independently on each cell or :meth:`preprocess` if you prefer your own logic.
+# See corresponding docstring for informations.
+# 
+# Disabled by default and can be enabled via the config by
+#     'c.YourPreprocessorName.enabled = True'
+
+# Preprocessor will inherit config from: NbConvertBase
+
+# 
+# c.Preprocessor.enabled = False
+
+# DEPRECATED default highlight language, please use language_info metadata
+# instead
+# c.Preprocessor.default_language = 'ipython'
+
+# An ordered list of preferred output type, the first encountered will usually
+# be used when converting discarding the others.
+# c.Preprocessor.display_data_priority = ['text/html', 'application/pdf', 'text/latex', 'image/svg+xml', 'image/png', 'image/jpeg', 'text/plain']
+
+#------------------------------------------------------------------------------
+# RevealHelpPreprocessor configuration
+#------------------------------------------------------------------------------
+
+# RevealHelpPreprocessor will inherit config from: Preprocessor, NbConvertBase
+
+# 
+# c.RevealHelpPreprocessor.enabled = False
+
+# DEPRECATED default highlight language, please use language_info metadata
+# instead
+# c.RevealHelpPreprocessor.default_language = 'ipython'
+
+# The URL prefix for reveal.js. This can be a a relative URL for a local copy of
+# reveal.js, or point to a CDN.
+# 
+# For speaker notes to work, a local reveal.js prefix must be used.
+# c.RevealHelpPreprocessor.url_prefix = 'reveal.js'
+
+# An ordered list of preferred output type, the first encountered will usually
+# be used when converting discarding the others.
+# c.RevealHelpPreprocessor.display_data_priority = ['text/html', 'application/pdf', 'text/latex', 'image/svg+xml', 'image/png', 'image/jpeg', 'text/plain']
+
+#------------------------------------------------------------------------------
+# SVG2PDFPreprocessor configuration
+#------------------------------------------------------------------------------
+
+# Converts all of the outputs in a notebook from SVG to PDF.
+
+# SVG2PDFPreprocessor will inherit config from: ConvertFiguresPreprocessor,
+# Preprocessor, NbConvertBase
+
+# Format the converter writes
+# c.SVG2PDFPreprocessor.to_format = ''
+
+# The path to Inkscape, if necessary
+# c.SVG2PDFPreprocessor.inkscape = ''
+
+# Format the converter accepts
+# c.SVG2PDFPreprocessor.from_format = ''
+
+# The command to use for converting SVG to PDF
+# 
+# This string is a template, which will be formatted with the keys to_filename
+# and from_filename.
+# 
+# The conversion call must read the SVG from {from_flename}, and write a PDF to
+# {to_filename}.
+# c.SVG2PDFPreprocessor.command = ''
+
+# DEPRECATED default highlight language, please use language_info metadata
+# instead
+# c.SVG2PDFPreprocessor.default_language = 'ipython'
+
+# 
+# c.SVG2PDFPreprocessor.enabled = False
+
+# An ordered list of preferred output type, the first encountered will usually
+# be used when converting discarding the others.
+# c.SVG2PDFPreprocessor.display_data_priority = ['text/html', 'application/pdf', 'text/latex', 'image/svg+xml', 'image/png', 'image/jpeg', 'text/plain']
+
+#------------------------------------------------------------------------------
+# FilesWriter configuration
+#------------------------------------------------------------------------------
+
+# Consumes nbconvert output and produces files.
+
+# FilesWriter will inherit config from: WriterBase, NbConvertBase
+
+# DEPRECATED default highlight language, please use language_info metadata
+# instead
+# c.FilesWriter.default_language = 'ipython'
+
+# When copying files that the notebook depends on, copy them in relation to this
+# path, such that the destination filename will be os.path.relpath(filename,
+# relpath). If FilesWriter is operating on a notebook that already exists
+# elsewhere on disk, then the default will be the directory containing that
+# notebook.
+# c.FilesWriter.relpath = ''
+
+# Directory to write output to.  Leave blank to output to the current directory
+# c.FilesWriter.build_directory = ''
+
+# List of the files that the notebook references.  Files will be  included with
+# written output.
+# c.FilesWriter.files = []
+
+# An ordered list of preferred output type, the first encountered will usually
+# be used when converting discarding the others.
+# c.FilesWriter.display_data_priority = ['text/html', 'application/pdf', 'text/latex', 'image/svg+xml', 'image/png', 'image/jpeg', 'text/plain']
+
+#------------------------------------------------------------------------------
+# StdoutWriter configuration
+#------------------------------------------------------------------------------
+
+# Consumes output from nbconvert export...() methods and writes to the  stdout
+# stream.
+
+# StdoutWriter will inherit config from: WriterBase, NbConvertBase
+
+# DEPRECATED default highlight language, please use language_info metadata
+# instead
+# c.StdoutWriter.default_language = 'ipython'
+
+# List of the files that the notebook references.  Files will be  included with
+# written output.
+# c.StdoutWriter.files = []
+
+# An ordered list of preferred output type, the first encountered will usually
+# be used when converting discarding the others.
+# c.StdoutWriter.display_data_priority = ['text/html', 'application/pdf', 'text/latex', 'image/svg+xml', 'image/png', 'image/jpeg', 'text/plain']
+
+#------------------------------------------------------------------------------
+# WriterBase configuration
+#------------------------------------------------------------------------------
+
+# Consumes output from nbconvert export...() methods and writes to a useful
+# location.
+
+# WriterBase will inherit config from: NbConvertBase
+
+# DEPRECATED default highlight language, please use language_info metadata
+# instead
+# c.WriterBase.default_language = 'ipython'
+
+# List of the files that the notebook references.  Files will be  included with
+# written output.
+# c.WriterBase.files = []
+
+# An ordered list of preferred output type, the first encountered will usually
+# be used when converting discarding the others.
+# c.WriterBase.display_data_priority = ['text/html', 'application/pdf', 'text/latex', 'image/svg+xml', 'image/png', 'image/jpeg', 'text/plain']
+
+#------------------------------------------------------------------------------
+# PostProcessorBase configuration
+#------------------------------------------------------------------------------
+
+# PostProcessorBase will inherit config from: NbConvertBase
+
+# DEPRECATED default highlight language, please use language_info metadata
+# instead
+# c.PostProcessorBase.default_language = 'ipython'
+
+# An ordered list of preferred output type, the first encountered will usually
+# be used when converting discarding the others.
+# c.PostProcessorBase.display_data_priority = ['text/html', 'application/pdf', 'text/latex', 'image/svg+xml', 'image/png', 'image/jpeg', 'text/plain']
+
+#------------------------------------------------------------------------------
+# ServePostProcessor configuration
+#------------------------------------------------------------------------------
+
+# Post processor designed to serve files
+# 
+# Proxies reveal.js requests to a CDN if no local reveal.js is present
+
+# ServePostProcessor will inherit config from: PostProcessorBase, NbConvertBase
+
+# URL prefix for reveal.js
+# c.ServePostProcessor.reveal_prefix = 'reveal.js'
+
+# Should the browser be opened automatically?
+# c.ServePostProcessor.open_in_browser = True
+
+# An ordered list of preferred output type, the first encountered will usually
+# be used when converting discarding the others.
+# c.ServePostProcessor.display_data_priority = ['text/html', 'application/pdf', 'text/latex', 'image/svg+xml', 'image/png', 'image/jpeg', 'text/plain']
+
+# DEPRECATED default highlight language, please use language_info metadata
+# instead
+# c.ServePostProcessor.default_language = 'ipython'
+
+# port for the server to listen on.
+# c.ServePostProcessor.port = 8000
+
+# URL for reveal.js CDN.
+# c.ServePostProcessor.reveal_cdn = 'https://cdn.jsdelivr.net/reveal.js/2.6.2'
+
+# The IP address to listen on.
+# c.ServePostProcessor.ip = '127.0.0.1'

--- a/jupyter_core/tests/dotipython_empty/profile_default/ipython_notebook_config.py
+++ b/jupyter_core/tests/dotipython_empty/profile_default/ipython_notebook_config.py
@@ -1,0 +1,548 @@
+# Configuration file for ipython-notebook.
+
+c = get_config()
+
+#------------------------------------------------------------------------------
+# NotebookApp configuration
+#------------------------------------------------------------------------------
+
+# NotebookApp will inherit config from: BaseIPythonApplication, Application
+
+# Supply SSL options for the tornado HTTPServer. See the tornado docs for
+# details.
+# c.NotebookApp.ssl_options = {}
+
+# The config manager class to use
+# c.NotebookApp.config_manager_class = <class 'IPython.html.services.config.manager.ConfigManager'>
+
+# Hashed password to use for web authentication.
+# 
+# To generate, type in a python/IPython shell:
+# 
+#   from IPython.lib import passwd; passwd()
+# 
+# The string should be of the form type:salt:hashed-password.
+# c.NotebookApp.password = ''
+
+# The number of additional ports to try if the specified port is not available.
+# c.NotebookApp.port_retries = 50
+
+# The kernel manager class to use.
+# c.NotebookApp.kernel_manager_class = <class 'IPython.html.services.kernels.kernelmanager.MappingKernelManager'>
+
+# The port the notebook server will listen on.
+# c.NotebookApp.port = 8888
+
+# Set the log level by value or name.
+# c.NotebookApp.log_level = 30
+
+# Path to an extra config file to load.
+# 
+# If specified, load this config file in addition to any other IPython config.
+# c.NotebookApp.extra_config_file = ''
+
+# The cluster manager class to use.
+# c.NotebookApp.cluster_manager_class = <class 'IPython.html.services.clusters.clustermanager.ClusterManager'>
+
+# The base URL for the notebook server.
+# 
+# Leading and trailing slashes can be omitted, and will automatically be added.
+# c.NotebookApp.base_url = '/'
+
+# Python modules to load as notebook server extensions. This is an experimental
+# API, and may change in future releases.
+# c.NotebookApp.server_extensions = []
+
+# The login handler class to use.
+# c.NotebookApp.login_handler_class = <class 'IPython.html.auth.login.LoginHandler'>
+
+# The session manager class to use.
+# c.NotebookApp.session_manager_class = <class 'IPython.html.services.sessions.sessionmanager.SessionManager'>
+
+# Set the Access-Control-Allow-Origin header
+# 
+# Use '*' to allow any origin to access your server.
+# 
+# Takes precedence over allow_origin_pat.
+# c.NotebookApp.allow_origin = ''
+
+# Whether to enable MathJax for typesetting math/TeX
+# 
+# MathJax is the javascript library IPython uses to render math/LaTeX. It is
+# very large, so you may want to disable it if you have a slow internet
+# connection, or for offline use of the notebook.
+# 
+# When disabled, equations etc. will appear as their untransformed TeX source.
+# c.NotebookApp.enable_mathjax = True
+
+# The notebook manager class to use.
+# c.NotebookApp.contents_manager_class = <class 'IPython.html.services.contents.filemanager.FileContentsManager'>
+
+# The full path to an SSL/TLS certificate file.
+# c.NotebookApp.certfile = ''
+
+# Set the Access-Control-Allow-Credentials: true header
+# c.NotebookApp.allow_credentials = False
+
+# The Logging format template
+# c.NotebookApp.log_format = '[%(name)s]%(highlevel)s %(message)s'
+
+# The base URL for websockets, if it differs from the HTTP server (hint: it
+# almost certainly doesn't).
+# 
+# Should be in the form of an HTTP origin: ws[s]://hostname[:port]
+# c.NotebookApp.websocket_url = ''
+
+# Use a regular expression for the Access-Control-Allow-Origin header
+# 
+# Requests from an origin matching the expression will get replies with:
+# 
+#     Access-Control-Allow-Origin: origin
+# 
+# where `origin` is the origin of the request.
+# 
+# Ignored if allow_origin is set.
+# c.NotebookApp.allow_origin_pat = ''
+
+# The date format used by logging formatters for %(asctime)s
+# c.NotebookApp.log_datefmt = '%Y-%m-%d %H:%M:%S'
+
+# The logout handler class to use.
+# c.NotebookApp.logout_handler_class = <class 'IPython.html.auth.logout.LogoutHandler'>
+
+# The default URL to redirect to from `/`
+# c.NotebookApp.default_url = '/tree'
+
+# The IPython profile to use.
+# c.NotebookApp.profile = 'default'
+
+# extra paths to look for Javascript notebook extensions
+# c.NotebookApp.extra_nbextensions_path = []
+
+# Specify what command to use to invoke a web browser when opening the notebook.
+# If not specified, the default browser will be determined by the `webbrowser`
+# standard library module, which allows setting of the BROWSER environment
+# variable to override it.
+# c.NotebookApp.browser = ''
+
+# The url for MathJax.js.
+# c.NotebookApp.mathjax_url = ''
+
+# Supply overrides for the tornado.web.Application that the IPython notebook
+# uses.
+# c.NotebookApp.tornado_settings = {}
+
+# The file where the cookie secret is stored.
+# c.NotebookApp.cookie_secret_file = ''
+
+# Create a massive crash report when IPython encounters what may be an internal
+# error.  The default is to append a short message to the usual traceback
+# c.NotebookApp.verbose_crash = False
+
+# Whether to overwrite existing config files when copying
+# c.NotebookApp.overwrite = False
+
+# Whether to open in a browser after starting. The specific browser used is
+# platform dependent and determined by the python standard library `webbrowser`
+# module, unless it is overridden using the --browser (NotebookApp.browser)
+# configuration option.
+# c.NotebookApp.open_browser = True
+
+# DEPRECATED, use tornado_settings
+# c.NotebookApp.webapp_settings = {}
+
+# Reraise exceptions encountered loading server extensions?
+# c.NotebookApp.reraise_server_extension_failures = False
+
+# Whether to install the default config files into the profile dir. If a new
+# profile is being created, and IPython contains config files for that profile,
+# then they will be staged into the new directory.  Otherwise, default config
+# files will be automatically generated.
+# c.NotebookApp.copy_config_files = False
+
+# DISABLED: use %pylab or %matplotlib in the notebook to enable matplotlib.
+# c.NotebookApp.pylab = 'disabled'
+
+# The directory to use for notebooks and kernels.
+# c.NotebookApp.notebook_dir = ''
+
+# The kernel spec manager class to use. Should be a subclass of
+# `IPython.kernel.kernelspec.KernelSpecManager`.
+# 
+# The Api of KernelSpecManager is provisional and might change without warning
+# between this version of IPython and the next stable one.
+# c.NotebookApp.kernel_spec_manager_class = <class 'IPython.kernel.kernelspec.KernelSpecManager'>
+
+# 
+# c.NotebookApp.file_to_run = ''
+
+# DEPRECATED use base_url
+# c.NotebookApp.base_project_url = '/'
+
+# The random bytes used to secure cookies. By default this is a new random
+# number every time you start the Notebook. Set it to a value in a config file
+# to enable logins to persist across server sessions.
+# 
+# Note: Cookie secrets should be kept private, do not share config files with
+# cookie_secret stored in plaintext (you can read the value from a file).
+# c.NotebookApp.cookie_secret = b''
+
+# The full path to a private key file for usage with SSL/TLS.
+# c.NotebookApp.keyfile = ''
+
+# Extra paths to search for serving static files.
+# 
+# This allows adding javascript/css to be available from the notebook server
+# machine, or overriding individual files in the IPython
+# c.NotebookApp.extra_static_paths = []
+
+# The name of the IPython directory. This directory is used for logging
+# configuration (through profiles), history storage, etc. The default is usually
+# $HOME/.ipython. This option can also be specified through the environment
+# variable IPYTHONDIR.
+# c.NotebookApp.ipython_dir = ''
+
+# Extra paths to search for serving jinja templates.
+# 
+# Can be used to override templates from IPython.html.templates.
+# c.NotebookApp.extra_template_paths = []
+
+# Whether to trust or not X-Scheme/X-Forwarded-Proto and X-Real-Ip/X-Forwarded-
+# For headerssent by the upstream reverse proxy. Necessary if the proxy handles
+# SSL
+# c.NotebookApp.trust_xheaders = False
+
+# Supply extra arguments that will be passed to Jinja environment.
+# c.NotebookApp.jinja_environment_options = {}
+
+# The IP address the notebook server will listen on.
+# c.NotebookApp.ip = 'localhost'
+
+#------------------------------------------------------------------------------
+# KernelManager configuration
+#------------------------------------------------------------------------------
+
+# Manages a single kernel in a subprocess on this host.
+# 
+# This version starts kernels with Popen.
+
+# KernelManager will inherit config from: ConnectionFileMixin
+
+# set the heartbeat port [default: random]
+# c.KernelManager.hb_port = 0
+
+# set the stdin (ROUTER) port [default: random]
+# c.KernelManager.stdin_port = 0
+
+# 
+# c.KernelManager.transport = 'tcp'
+
+# JSON file in which to store connection info [default: kernel-<pid>.json]
+# 
+# This file will contain the IP, ports, and authentication key needed to connect
+# clients to this kernel. By default, this file will be created in the security
+# dir of the current profile, but can be specified by absolute path.
+# c.KernelManager.connection_file = ''
+
+# set the control (ROUTER) port [default: random]
+# c.KernelManager.control_port = 0
+
+# set the shell (ROUTER) port [default: random]
+# c.KernelManager.shell_port = 0
+
+# Should we autorestart the kernel if it dies.
+# c.KernelManager.autorestart = False
+
+# DEPRECATED: Use kernel_name instead.
+# 
+# The Popen Command to launch the kernel. Override this if you have a custom
+# kernel. If kernel_cmd is specified in a configuration file, IPython does not
+# pass any arguments to the kernel, because it cannot make any assumptions about
+# the  arguments that the kernel understands. In particular, this means that the
+# kernel does not receive the option --debug if it given on the IPython command
+# line.
+# c.KernelManager.kernel_cmd = []
+
+# Set the kernel's IP address [default localhost]. If the IP address is
+# something other than localhost, then Consoles on other machines will be able
+# to connect to the Kernel, so be careful!
+# c.KernelManager.ip = ''
+
+# set the iopub (PUB) port [default: random]
+# c.KernelManager.iopub_port = 0
+
+#------------------------------------------------------------------------------
+# ProfileDir configuration
+#------------------------------------------------------------------------------
+
+# An object to manage the profile directory and its resources.
+# 
+# The profile directory is used by all IPython applications, to manage
+# configuration, logging and security.
+# 
+# This object knows how to find, create and manage these directories. This
+# should be used by any code that wants to handle profiles.
+
+# Set the profile location directly. This overrides the logic used by the
+# `profile` option.
+# c.ProfileDir.location = ''
+
+#------------------------------------------------------------------------------
+# Session configuration
+#------------------------------------------------------------------------------
+
+# Object for handling serialization and sending of messages.
+# 
+# The Session object handles building messages and sending them with ZMQ sockets
+# or ZMQStream objects.  Objects can communicate with each other over the
+# network via Session objects, and only need to work with the dict-based IPython
+# message spec. The Session will handle serialization/deserialization, security,
+# and metadata.
+# 
+# Sessions support configurable serialization via packer/unpacker traits, and
+# signing with HMAC digests via the key/keyfile traits.
+# 
+# Parameters ----------
+# 
+# debug : bool
+#     whether to trigger extra debugging statements
+# packer/unpacker : str : 'json', 'pickle' or import_string
+#     importstrings for methods to serialize message parts.  If just
+#     'json' or 'pickle', predefined JSON and pickle packers will be used.
+#     Otherwise, the entire importstring must be used.
+# 
+#     The functions must accept at least valid JSON input, and output *bytes*.
+# 
+#     For example, to use msgpack:
+#     packer = 'msgpack.packb', unpacker='msgpack.unpackb'
+# pack/unpack : callables
+#     You can also set the pack/unpack callables for serialization directly.
+# session : bytes
+#     the ID of this Session object.  The default is to generate a new UUID.
+# username : unicode
+#     username added to message headers.  The default is to ask the OS.
+# key : bytes
+#     The key used to initialize an HMAC signature.  If unset, messages
+#     will not be signed or checked.
+# keyfile : filepath
+#     The file containing a key.  If this is set, `key` will be initialized
+#     to the contents of the file.
+
+# The digest scheme used to construct the message signatures. Must have the form
+# 'hmac-HASH'.
+# c.Session.signature_scheme = 'hmac-sha256'
+
+# The maximum number of digests to remember.
+# 
+# The digest history will be culled when it exceeds this value.
+# c.Session.digest_history_size = 65536
+
+# The name of the unpacker for unserializing messages. Only used with custom
+# functions for `packer`.
+# c.Session.unpacker = 'json'
+
+# The name of the packer for serializing messages. Should be one of 'json',
+# 'pickle', or an import name for a custom callable serializer.
+# c.Session.packer = 'json'
+
+# Username for the Session. Default is your system username.
+# c.Session.username = 'minrk'
+
+# Debug output in the Session
+# c.Session.debug = False
+
+# path to file containing execution key.
+# c.Session.keyfile = ''
+
+# The maximum number of items for a container to be introspected for custom
+# serialization. Containers larger than this are pickled outright.
+# c.Session.item_threshold = 64
+
+# Threshold (in bytes) beyond which an object's buffer should be extracted to
+# avoid pickling.
+# c.Session.buffer_threshold = 1024
+
+# The UUID identifying this session.
+# c.Session.session = ''
+
+# Threshold (in bytes) beyond which a buffer should be sent without copying.
+# c.Session.copy_threshold = 65536
+
+# execution key, for signing messages.
+# c.Session.key = b''
+
+# Metadata dictionary, which serves as the default top-level metadata dict for
+# each message.
+# c.Session.metadata = {}
+
+#------------------------------------------------------------------------------
+# MappingKernelManager configuration
+#------------------------------------------------------------------------------
+
+# A KernelManager that handles notebook mapping and HTTP error handling
+
+# MappingKernelManager will inherit config from: MultiKernelManager
+
+# The kernel manager class.  This is configurable to allow subclassing of the
+# KernelManager for customized behavior.
+# c.MappingKernelManager.kernel_manager_class = 'IPython.kernel.ioloop.IOLoopKernelManager'
+
+# 
+# c.MappingKernelManager.root_dir = ''
+
+# The name of the default kernel to start
+# c.MappingKernelManager.default_kernel_name = 'python3'
+
+#------------------------------------------------------------------------------
+# ContentsManager configuration
+#------------------------------------------------------------------------------
+
+# Base class for serving files and directories.
+# 
+# This serves any text or binary file, as well as directories, with special
+# handling for JSON notebook documents.
+# 
+# Most APIs take a path argument, which is always an API-style unicode path, and
+# always refers to a directory.
+# 
+# - unicode, not url-escaped
+# - '/'-separated
+# - leading and trailing '/' will be stripped
+# - if unspecified, path defaults to '',
+#   indicating the root path.
+
+# The base name used when creating untitled directories.
+# c.ContentsManager.untitled_directory = 'Untitled Folder'
+
+# Python callable or importstring thereof
+# 
+# To be called on a contents model prior to save.
+# 
+# This can be used to process the structure, such as removing notebook outputs
+# or other side effects that should not be saved.
+# 
+# It will be called as (all arguments passed by keyword)::
+# 
+#     hook(path=path, model=model, contents_manager=self)
+# 
+# - model: the model to be saved. Includes file contents.
+#   Modifying this dict will affect the file that is stored.
+# - path: the API path of the save destination
+# - contents_manager: this ContentsManager instance
+# c.ContentsManager.pre_save_hook = None
+
+# Glob patterns to hide in file and directory listings.
+# c.ContentsManager.hide_globs = ['__pycache__', '*.pyc', '*.pyo', '.DS_Store', '*.so', '*.dylib', '*~']
+
+# The base name used when creating untitled files.
+# c.ContentsManager.untitled_file = 'untitled'
+
+# The base name used when creating untitled notebooks.
+# c.ContentsManager.untitled_notebook = 'Untitled'
+
+# 
+# c.ContentsManager.checkpoints = None
+
+# 
+# c.ContentsManager.checkpoints_class = <class 'IPython.html.services.contents.checkpoints.Checkpoints'>
+
+# 
+# c.ContentsManager.checkpoints_kwargs = {}
+
+#------------------------------------------------------------------------------
+# FileContentsManager configuration
+#------------------------------------------------------------------------------
+
+# FileContentsManager will inherit config from: ContentsManager
+
+# The base name used when creating untitled directories.
+# c.FileContentsManager.untitled_directory = 'Untitled Folder'
+
+# Python callable or importstring thereof
+# 
+# To be called on a contents model prior to save.
+# 
+# This can be used to process the structure, such as removing notebook outputs
+# or other side effects that should not be saved.
+# 
+# It will be called as (all arguments passed by keyword)::
+# 
+#     hook(path=path, model=model, contents_manager=self)
+# 
+# - model: the model to be saved. Includes file contents.
+#   Modifying this dict will affect the file that is stored.
+# - path: the API path of the save destination
+# - contents_manager: this ContentsManager instance
+# c.FileContentsManager.pre_save_hook = None
+
+# Glob patterns to hide in file and directory listings.
+# c.FileContentsManager.hide_globs = ['__pycache__', '*.pyc', '*.pyo', '.DS_Store', '*.so', '*.dylib', '*~']
+
+# The base name used when creating untitled files.
+# c.FileContentsManager.untitled_file = 'untitled'
+
+# The base name used when creating untitled notebooks.
+# c.FileContentsManager.untitled_notebook = 'Untitled'
+
+# Python callable or importstring thereof
+# 
+# to be called on the path of a file just saved.
+# 
+# This can be used to process the file on disk, such as converting the notebook
+# to a script or HTML via nbconvert.
+# 
+# It will be called as (all arguments passed by keyword)::
+# 
+#     hook(os_path=os_path, model=model, contents_manager=instance)
+# 
+# - path: the filesystem path to the file just written - model: the model
+# representing the file - contents_manager: this ContentsManager instance
+# c.FileContentsManager.post_save_hook = None
+
+# DEPRECATED, use post_save_hook
+# c.FileContentsManager.save_script = False
+
+# 
+# c.FileContentsManager.root_dir = ''
+
+# 
+# c.FileContentsManager.checkpoints_class = <class 'IPython.html.services.contents.checkpoints.Checkpoints'>
+
+# 
+# c.FileContentsManager.checkpoints = None
+
+# 
+# c.FileContentsManager.checkpoints_kwargs = {}
+
+#------------------------------------------------------------------------------
+# NotebookNotary configuration
+#------------------------------------------------------------------------------
+
+# A class for computing and verifying notebook signatures.
+
+# The number of notebook signatures to cache. When the number of signatures
+# exceeds this value, the oldest 25% of signatures will be culled.
+# c.NotebookNotary.cache_size = 65535
+
+# The sqlite file in which to store notebook signatures. By default, this will
+# be in your IPython profile. You can set it to ':memory:' to disable sqlite
+# writing to the filesystem.
+# c.NotebookNotary.db_file = ''
+
+# The secret key with which notebooks are signed.
+# c.NotebookNotary.secret = b''
+
+# The file where the secret key is stored.
+# c.NotebookNotary.secret_file = ''
+
+# The hashing algorithm used to sign notebooks.
+# c.NotebookNotary.algorithm = 'sha256'
+
+#------------------------------------------------------------------------------
+# KernelSpecManager configuration
+#------------------------------------------------------------------------------
+
+# Whitelist of allowed kernel names.
+# 
+# By default, all installed kernels are allowed.
+# c.KernelSpecManager.whitelist = set()

--- a/jupyter_core/tests/dotipython_empty/profile_default/static/custom/custom.css
+++ b/jupyter_core/tests/dotipython_empty/profile_default/static/custom/custom.css
@@ -1,0 +1,7 @@
+/*
+Placeholder for custom user CSS
+
+mainly to be overridden in profile/static/custom/custom.css
+
+This will always be an empty file in IPython
+*/

--- a/jupyter_core/tests/dotipython_empty/profile_default/static/custom/custom.js
+++ b/jupyter_core/tests/dotipython_empty/profile_default/static/custom/custom.js
@@ -1,0 +1,82 @@
+// leave at least 2 line with only a star on it below, or doc generation fails
+/**
+ *
+ *
+ * Placeholder for custom user javascript
+ * mainly to be overridden in profile/static/custom/custom.js
+ * This will always be an empty file in IPython
+ *
+ * User could add any javascript in the `profile/static/custom/custom.js` file.
+ * It will be executed by the ipython notebook at load time.
+ *
+ * Same thing with `profile/static/custom/custom.css` to inject custom css into the notebook.
+ *
+ *
+ * The object available at load time depend on the version of IPython in use.
+ * there is no guaranties of API stability.
+ *
+ * The example below explain the principle, and might not be valid.
+ *
+ * Instances are created after the loading of this file and might need to be accessed using events:
+ *     define([
+ *        'base/js/namespace',
+ *        'base/js/events'
+ *     ], function(IPython, events) {
+ *         events.on("app_initialized.NotebookApp", function () {
+ *             IPython.keyboard_manager....
+ *         });
+ *     });
+ *
+ * __Example 1:__
+ *
+ * Create a custom button in toolbar that execute `%qtconsole` in kernel
+ * and hence open a qtconsole attached to the same kernel as the current notebook
+ *
+ *    define([
+ *        'base/js/namespace',
+ *        'base/js/events'
+ *    ], function(IPython, events) {
+ *        events.on('app_initialized.NotebookApp', function(){
+ *            IPython.toolbar.add_buttons_group([
+ *                {
+ *                    'label'   : 'run qtconsole',
+ *                    'icon'    : 'icon-terminal', // select your icon from http://fortawesome.github.io/Font-Awesome/icons
+ *                    'callback': function () {
+ *                        IPython.notebook.kernel.execute('%qtconsole')
+ *                    }
+ *                }
+ *                // add more button here if needed.
+ *                ]);
+ *        });
+ *    });
+ *
+ * __Example 2:__
+ *
+ * At the completion of the dashboard loading, load an unofficial javascript extension
+ * that is installed in profile/static/custom/
+ *
+ *    define([
+ *        'base/js/events'
+ *    ], function(events) {
+ *        events.on('app_initialized.DashboardApp', function(){
+ *            require(['custom/unofficial_extension.js'])
+ *        });
+ *    });
+ *
+ * __Example 3:__
+ *
+ *  Use `jQuery.getScript(url [, success(script, textStatus, jqXHR)] );`
+ *  to load custom script into the notebook.
+ *
+ *    // to load the metadata ui extension example.
+ *    $.getScript('/static/notebook/js/celltoolbarpresets/example.js');
+ *    // or
+ *    // to load the metadata ui extension to control slideshow mode / reveal js for nbconvert
+ *    $.getScript('/static/notebook/js/celltoolbarpresets/slideshow.js');
+ *
+ *
+ * @module IPython
+ * @namespace IPython
+ * @class customjs
+ * @static
+ */

--- a/jupyter_core/tests/test_migrate.py
+++ b/jupyter_core/tests/test_migrate.py
@@ -1,0 +1,219 @@
+"""Test config file migration"""
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+import os
+import re
+import shutil
+from subprocess import check_call
+from tempfile import mkdtemp
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
+
+import pytest
+
+from ipython_genutils.path import ensure_dir_exists
+try:
+    from IPython.paths import locate_profile
+except ImportError:
+    from IPython.utils.path import locate_profile
+
+from jupyter_core.paths import jupyter_data_dir
+from jupyter_core.migrate import (
+    migrate, migrate_one, migrate_config,
+    migrate_dir, migrate_file, migrate_static_custom,
+)
+from jupyter_core import migrate as migrate_mod
+
+pjoin = os.path.join
+here = os.path.dirname(__file__)
+dotipython = pjoin(here, 'dotipython')
+dotipython_empty = pjoin(here, 'dotipython_empty')
+
+
+@pytest.fixture
+def td(request):
+    """Fixture for a temporary directory"""
+    td = mkdtemp()
+    request.addfinalizer(lambda : shutil.rmtree(td))
+    return td
+
+@pytest.fixture
+def env(request):
+    """Fixture for a full testing environment"""
+    td = mkdtemp()
+    env = {
+        'TESTDIR': td,
+        'IPYTHONDIR': pjoin(td, 'ipython'),
+        'JUPYTER_CONFIG_DIR': pjoin(td, 'jupyter'),
+        'JUPYTER_DATA_DIR': pjoin(td, 'jupyter_data'),
+        'JUPYTER_RUNTIME_DIR': pjoin(td, 'jupyter_runtime'),
+        'JUPYTER_PATH': '',
+    }
+    env_patch = patch.dict(os.environ, env)
+    env_patch.start()
+    
+    def fin():
+        """Cleanup test env"""
+        env_patch.stop()
+        shutil.rmtree(td)
+    request.addfinalizer(fin)
+    
+    return env
+
+
+def touch(path, content=''):
+    ensure_dir_exists(os.path.dirname(path))
+    with open(path, 'w') as f:
+        f.write(content)
+
+
+def assert_files_equal(a, b):
+    """Verify that two files match"""
+    
+    assert os.path.exists(b)
+    with open(a) as f:
+        a_txt = f.read()
+    
+    with open(b) as f:
+        b_txt = f.read()
+    
+    assert a_txt == b_txt
+
+
+def test_migrate_file(td):
+    src = pjoin(td, 'src')
+    dst = pjoin(td, 'dst')
+    touch(src, 'test file')
+    assert migrate_file(src, dst)
+    assert_files_equal(src, dst)
+    
+    src2 = pjoin(td, 'src2')
+    touch(src2, 'different src')
+    assert not migrate_file(src2, dst)
+    assert_files_equal(src, dst)
+
+
+def test_migrate_dir(td):
+    src = pjoin(td, 'src')
+    dst = pjoin(td, 'dst')
+    os.mkdir(src)
+    assert not migrate_dir(src, dst)
+    assert not os.path.exists(dst)
+    
+    touch(pjoin(src, 'f'), 'test file')
+    assert migrate_dir(src, dst)
+    assert_files_equal(pjoin(src, 'f'), pjoin(dst, 'f'))
+    
+    touch(pjoin(src, 'g'), 'other test file')
+    assert not migrate_dir(src, dst)
+    assert not os.path.exists(pjoin(dst, 'g'))
+    
+    shutil.rmtree(dst)
+    os.mkdir(dst)
+    assert migrate_dir(src, dst)
+    assert_files_equal(pjoin(src, 'f'), pjoin(dst, 'f'))
+    assert_files_equal(pjoin(src, 'g'), pjoin(dst, 'g'))
+
+
+def test_migrate_one(td):
+    src = pjoin(td, 'src')
+    srcdir = pjoin(td, 'srcdir')
+    dst = pjoin(td, 'dst')
+    dstdir = pjoin(td, 'dstdir')
+    
+    touch(src, 'test file')
+    touch(pjoin(srcdir, 'f'), 'test dir file')
+    
+    called = {}
+    def notice_m_file(src, dst):
+        called['migrate_file'] = True
+        return migrate_file(src, dst)
+    
+    def notice_m_dir(src, dst):
+        called['migrate_dir'] = True
+        return migrate_dir(src, dst)
+    
+    with patch.object(migrate_mod, 'migrate_file', notice_m_file), \
+            patch.object(migrate_mod, 'migrate_dir', notice_m_dir):
+        assert migrate_one(src, dst)
+        assert called == {'migrate_file': True}
+        called.clear()
+        assert migrate_one(srcdir, dstdir)
+        assert called == {'migrate_dir': True}
+        called.clear()
+        assert not migrate_one(pjoin(td, 'dne'), dst)
+        assert called == {}
+
+
+def test_migrate_config(td):
+    profile = pjoin(td, 'profile')
+    jpy = pjoin(td, 'jupyter_config')
+    ensure_dir_exists(profile)
+    
+    env = {
+        'profile': profile,
+        'jupyter_config': jpy,
+    }
+    cfg_py = pjoin(profile, 'ipython_test_config.py')
+    touch(cfg_py, 'c.Klass.trait = 5\n')
+    empty_cfg_py = pjoin(profile, 'ipython_empty_config.py')
+    touch(empty_cfg_py, '# c.Klass.trait = 5\n')
+    
+    assert not migrate_config('empty', env)
+    assert not os.path.exists(jpy)
+    
+    with patch.dict(migrate_mod.config_substitutions, {
+        re.compile(r'\bKlass\b'): 'Replaced',
+    }):
+        assert migrate_config('test', env)
+    
+    assert os.path.isdir(jpy)
+    assert sorted(os.listdir(jpy)) == [
+        'jupyter_test_config.py',
+    ]
+    
+    with open(pjoin(jpy, 'jupyter_test_config.py')) as f:
+        text = f.read()
+    assert text == 'c.Replaced.trait = 5\n'
+
+
+def test_migrate_custom_default(td):
+    profile = pjoin(dotipython, 'profile_default')
+    src = pjoin(profile, 'static', 'custom')
+    assert os.path.exists(src)
+    assert not migrate_static_custom(src, td)
+    
+    src = pjoin(td, 'src')
+    dst = pjoin(td, 'dst')
+    os.mkdir(src)
+    src_custom_js = pjoin(src, 'custom.js')
+    src_custom_css = pjoin(src, 'custom.css')
+    touch(src_custom_js, 'var a=5;')
+    touch(src_custom_css, 'div { height: 5px; }')
+
+    assert migrate_static_custom(src, dst)
+
+
+def test_migrate_nothing(env):
+    migrate()
+    assert not os.path.exists(env['JUPYTER_CONFIG_DIR'])
+    assert not os.path.exists(env['JUPYTER_DATA_DIR'])
+
+
+def test_migrate_default(env):
+    shutil.copytree(dotipython_empty, env['IPYTHONDIR'])
+    migrate()
+    assert not os.path.exists(env['JUPYTER_CONFIG_DIR'])
+    assert not os.path.exists(env['JUPYTER_DATA_DIR'])
+
+
+def test_migrate(env):
+    shutil.copytree(dotipython, env['IPYTHONDIR'])
+    migrate()
+    assert os.path.exists(env['JUPYTER_CONFIG_DIR'])
+    assert os.path.exists(env['JUPYTER_DATA_DIR'])
+
+

--- a/scripts/jupyter-migrate
+++ b/scripts/jupyter-migrate
@@ -1,0 +1,7 @@
+#!/usr/bin/env python
+"""Migrate Jupyter config from IPython < 4.0"""
+
+from jupyter_core.migrate import main
+
+if __name__ == '__main__':
+    main()

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ from __future__ import print_function
 
 import os
 import sys
+from glob import glob
 
 v = sys.version_info
 if v[:2] < (2,7) or (v[:2] > (3,) and v[:2] < (3,3)):
@@ -35,7 +36,7 @@ setup_args = dict(
     name                = 'jupyter_core',
     version             = version_ns['__version__'],
     packages            = ['jupyter_core'],
-    scripts             = ['scripts/jupyter'],
+    scripts             = glob(pjoin('scripts', '*')),
     description         = "Jupyter core package. A base package on which Jupyter projects rely.",
     long_description    = """There is no reason to install this package on its own.""",
     author              = "Jupyter Development Team",


### PR DESCRIPTION
Currently, this implements migration of config files and user-installed nbextensions, kernelspecs from IPython < 4.0 to Jupyter locations via `jupyter migrate` as:

- copy files to new locations
- if new locations already exist, do nothing
- never overwrite anything
- don't copy empty config files
- small amount of find-replace in config files for renamed classes (e.g. IPythonQtConsoleApp -> JupyterQtConsoleApp)

To figure out for this PR:

- [x] what files should be migrated
- [x] copy or move, etc.? Allow overwrite?
- [x] API for migration (CLI)
- [x] should there be any modifications to contents, or only copies?

To figure out after this PR:

- When to migrate.

I want to implement migration first, and work on implicit-on-startup logic, if any, as a separate discussion.

cc @takluyver @fperez @ellisonbg

closes #2