### PR TITLE
ensure SYSTEM_JUPYTER_PATH is never empty

### DIFF
--- a/jupyter_core/paths.py
+++ b/jupyter_core/paths.py
@@ -99,7 +99,7 @@ if os.name == 'nt':
     if programdata:
         SYSTEM_JUPYTER_PATH = [pjoin(programdata, 'jupyter')]
     else:  # PROGRAMDATA is not defined by default on XP.
-        SYSTEM_JUPYTER_PATH = []
+        SYSTEM_JUPYTER_PATH = [os.path.join(sys.prefix, 'share', 'jupyter')]
 else:
     SYSTEM_JUPYTER_PATH = [
         "/usr/local/share/jupyter",
@@ -107,6 +107,7 @@ else:
     ]
 
 ENV_JUPYTER_PATH = [os.path.join(sys.prefix, 'share', 'jupyter')]
+
 
 def jupyter_path(*subdirs):
     """Return the list of directories to search


### PR DESCRIPTION
even on XP, where PROGRAMDATA is undefined, in which case fall back on sys.prefix/share/jupyter.

If there's another sensible default on XP, that would be fine, too. I'm not actually sure we support XP anymore, so this may not matter, but I don't want it possible for this list to be empty.