### PR TITLE
XDG_RUNTIME_DIR, not XDG_RUNTIME_HOME

### DIFF
--- a/jupyter_core/paths.py
+++ b/jupyter_core/paths.py
@@ -74,7 +74,7 @@ def jupyter_runtime_dir():
     
     Returns JUPYTER_RUNTIME_DIR if defined.
     
-    Respects XDG_RUNTIME_HOME on non-OS X, non-Windows,
+    Respects XDG_RUNTIME_DIR on non-OS X, non-Windows,
     falls back on data_dir/runtime otherwise.
     """
     env = os.environ
@@ -88,7 +88,7 @@ def jupyter_runtime_dir():
         return pjoin(jupyter_data_dir(), 'runtime')
     else:
         # Linux, non-OS X Unix, AIX, etc.
-        xdg = env.get("XDG_RUNTIME_HOME", None)
+        xdg = env.get("XDG_RUNTIME_DIR", None)
         if xdg:
             return pjoin(xdg, 'jupyter')
         return pjoin(jupyter_data_dir(), 'runtime')

--- a/jupyter_core/tests/test_paths.py
+++ b/jupyter_core/tests/test_paths.py
@@ -23,13 +23,13 @@ pjoin = os.path.join
 xdg_env = {
     'XDG_CONFIG_HOME': '/tmp/xdg/config',
     'XDG_DATA_HOME': '/tmp/xdg/data',
-    'XDG_RUNTIME_HOME': '/tmp/xdg/runtime',
+    'XDG_RUNTIME_DIR': '/tmp/xdg/runtime',
 }
 xdg = patch.dict('os.environ', xdg_env)
 no_xdg = patch.dict('os.environ', {
     'XDG_CONFIG_HOME': '',
     'XDG_DATA_HOME': '',
-    'XDG_RUNTIME_HOME': '',
+    'XDG_RUNTIME_DIR': '',
 })
 
 appdata = patch.dict('os.environ', {'APPDATA': 'appdata'})
@@ -156,7 +156,7 @@ def test_runtime_dir_linux():
     
     with linux, xdg:
         runtime = jupyter_runtime_dir()
-    assert runtime == pjoin(xdg_env['XDG_RUNTIME_HOME'], 'jupyter')
+    assert runtime == pjoin(xdg_env['XDG_RUNTIME_DIR'], 'jupyter')
 
 
 def test_jupyter_path():


### PR DESCRIPTION
See http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html

Runtime is different from the other XDG directories in that it's a single directory, not a search path.