### PR TITLE
Add the kernelspec dirs to the json output

### DIFF
--- a/jupyter_core/command.py
+++ b/jupyter_core/command.py
@@ -100,6 +100,7 @@ def main():
             data['runtime'] = [paths.jupyter_runtime_dir()]
             data['config'] = paths.jupyter_config_path()
             data['data'] = paths.jupyter_path()
+            data['kernels'] = paths.jupyter_path("kernels")
             if args.json:
                 print(json.dumps(data))
             else:


### PR DESCRIPTION
This provides the listing of kernelspec dirs as part of the `jupyter --paths --json` output.

```
$ jupyter --paths --json | json
{
  "data": [
    "/Users/kyle6475/Library/Jupyter",
    "/usr/local/Cellar/python/2.7.9/Frameworks/Python.framework/Versions/2.7/share/jupyter",
    "/usr/local/share/jupyter",
    "/usr/share/jupyter"
  ],
  "runtime": [
    "/Users/kyle6475/Library/Jupyter/runtime"
  ],
  "config": [
    "/Users/kyle6475/.jupyter",
    "/usr/local/Cellar/python/2.7.9/Frameworks/Python.framework/Versions/2.7/etc/jupyter",
    "/usr/local/etc/jupyter",
    "/etc/jupyter"
  ],
  "kernels": [
    "/Users/kyle6475/Library/Jupyter/kernels",
    "/usr/local/Cellar/python/2.7.9/Frameworks/Python.framework/Versions/2.7/share/jupyter/kernels",
    "/usr/local/share/jupyter/kernels",
    "/usr/share/jupyter/kernels"
  ]
}
```

This is the same as taking the "data" list of directories and appending "kernels" to the end of each response, but then again that's exactly what jupyter_core does to produce the kernels output. Should this be kernelspecs?

It seems like we'd also want some way to query for where system kernels are (to be) installed vs. user installed kernels. This comes up in the context of kernel authors when wanting to install a kernel (https://github.com/n-riesco/ijavascript/blob/c2f6717bb0735b02b9602329e976c9023267ecf7/bin/ijavascript.js#L114-L131)

------------------------------------

On a separate note, in collaborating with people they're getting confused with our nomenclature especially when it isn't applied uniformly.

* Runtime == running kernels
* kernels dir == directory of kernelspec bundles
* kernels/**/kernel.json == kernelspec for a specific kernel
* kernelspecs is a definition of how to invoke a kernel

The problem I'm noticing is that we've been using kernel in the context of an available runtime, a running kernel, and the configuration for launching that kernel. It's practically the same kind of clashing between a container (running), an image (the bundled tarball with config), and a Dockerfile (specification to build it).