### PR TITLE
Use setuptools entry points when setuptools in use

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,9 +68,17 @@ setuptools_args['install_requires'] = [
     'traitlets',
 ]
 
+setuptools_args['entry_points'] = {
+    'console_scripts': [
+        'jupyter = jupyter_core.command:main',
+        'jupyter-migrate = jupyter_core.migrate:main',
+    ]
+}
+
 # setuptools requirements
 if 'setuptools' in sys.modules:
     setup_args.update(setuptools_args)
+    setup_args.pop('scripts', None)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Part of the fix for jupyter/jupyter#15 - using plain 'scripts', we don't
get the exe wrappers on Windows.

To fix it completely, we can either make the same change in all packages
installing scripts (notebook, nbconvert, qtconsole, console), or make
the recognition of subcommands a bit smarter to know about running
Python scripts without an exe wrapper. I'm inclined to do the former -
more pain right now, but probably less in the long term.

 @minrk, thoughts