### PR TITLE
don't use exec on Windows

### DIFF
--- a/jupyter_core/command.py
+++ b/jupyter_core/command.py
@@ -94,6 +94,10 @@ def _execvp(cmd, argv):
     """
     if sys.platform.startswith('win'):
         p = Popen([cmd] + argv[1:])
+        # Don't raise KeyboardInterrupt in the parent process.
+        # Set this after spawning, to avoid subprocess inheriting handler.
+        import signal
+        signal.signal(signal.SIGINT, signal.SIG_IGN)
         p.wait()
         sys.exit(p.returncode)
     else:


### PR DESCRIPTION
Use regular Popen instead.

Windows doesn't actually allow process replacement a la unix exec, but Python provides os.exec on Windows even though it doesn't actually work. It doesn't exec, it does fork & exec, which means the parent process returns immediately, and the 'true' process is put in the background.

The alternative is to use execfile on Windows, which would behave the same as exec on \*ix, with one exception: it forces all jupyter commands to be run with the same interpreter, rather than respecting shebang lines.

closes jupyter/nbconvert#103