### PR TITLE
install kernelspecs to datarootdir

### DIFF
--- a/jupyter_core/paths.py
+++ b/jupyter_core/paths.py
@@ -11,6 +11,7 @@
 
 import os
 import sys
+import sysconfig
 
 pjoin = os.path.join
 
@@ -99,9 +100,10 @@ if os.name == 'nt':
     if programdata:
         SYSTEM_JUPYTER_PATH = [pjoin(programdata, 'jupyter')]
     else:  # PROGRAMDATA is not defined by default on XP.
-        SYSTEM_JUPYTER_PATH = [os.path.join(sys.prefix, 'share', 'jupyter')]
+        SYSTEM_JUPYTER_PATH = [pjoin(sysconfig.get_config_var("datarootdir"), 'jupyter')]
 else:
     SYSTEM_JUPYTER_PATH = [
+        pjoin(sysconfig.get_config_var("datarootdir"), 'jupyter'),
         "/usr/local/share/jupyter",
         "/usr/share/jupyter",
     ]


### PR DESCRIPTION
There is currently no documented standard way of installing Jupyter kernels, leading to various different kernels doing it in a different way. The `echo_kernel` should be extended to a complete Python package, including `setup.py`.

The recommended way to install Jupyter kernel specs should be using distutils' `data_files`:
```
setup(...,
    data_files=("share/jupyter/kernels/MyKernel", [...])
)
```
We need to figure out how to emulate this behaviour for non-Python kernels.