### PR TITLE
import typo in test_command

### DIFF
--- a/jupyter_core/tests/test_command.py
+++ b/jupyter_core/tests/test_command.py
@@ -7,7 +7,7 @@ from subprocess import check_output, CalledProcessError
 
 import pytest
 try:
-    from unitteset.mock import patch
+    from unittest.mock import patch
 except ImportError:
     # py2
     from mock import patch


### PR DESCRIPTION
caused py2 import branch on all Python versions

This wasn't noticed because the `mock` package was installed anyway.