### PR TITLE
[WIP] install to envs by default

### DIFF
--- a/jupyter_core/command.py
+++ b/jupyter_core/command.py
@@ -132,14 +132,22 @@ def main():
             data['runtime'] = [paths.jupyter_runtime_dir()]
             data['config'] = paths.jupyter_config_path()
             data['data'] = paths.jupyter_path()
+            data['install_data'] = {
+                'user': paths.install_data_path('', user=True),
+                'default': paths.install_data_path('', user=False),
+            }
             if args.json:
                 print(json.dumps(data))
             else:
                 for name in sorted(data):
                     path = data[name]
                     print('%s:' % name)
-                    for p in path:
-                        print('    ' + p)
+                    if isinstance(path, dict):
+                        for key in sorted(path):
+                            print('    %7s: %s' % (key, path[key]))
+                    else:
+                        for p in path:
+                            print('    ' + p)
             return
     
     if not subcommand:

--- a/jupyter_core/paths.py
+++ b/jupyter_core/paths.py
@@ -150,6 +150,25 @@ ENV_JUPYTER_PATH = [pjoin(_sys_prefix, 'share', 'jupyter')]
 if _sys_prefix != sys.prefix:
     ENV_JUPYTER_PATH.append(pjoin(sys.prefix, 'share', 'jupyter'))
 
+def install_data_path(relative_path, user=False, prefix=None):
+    """Get install path for data files
+    
+    Installing tools, such as nbextension/kernelspec should use this to determine the install dir.
+    
+    if user=True: return JUPYTER_DATA_DIR
+    else: return default path for Python data files (*usually* sys.prefix/share/jupyter)
+    
+    .. versionadded:: 4.1
+    """
+    if user and prefix:
+        raise ValueError("Cannot specify both user and prefix")
+    if user:
+        data_dir = jupyter_data_dir()
+    else:
+        if prefix is None:
+            prefix = ENV_JUPYTER_PATH[0]
+        data_dir = pjoin(prefix, 'share', 'jupyter')
+    return pjoin(data_dir, relative_path)
 
 
 def jupyter_path(*subdirs):


### PR DESCRIPTION
Continuing the discussion in #61

Main proposed change: default installation of support files is in the current env, rather than /usr/local (or equivalent)

- add paths.install_data_path
  - Central API for specifying the installation path for a given file for  user=True|False.
  - Should ensure consistency for defaults, etc.
  - If accepted, this should be used exclusively to determine install paths for nbextensions/kernelspecs, etc.

This also asks disutils where data_files would go for both user=True|False, ensuring that Python packages can provide kernelspecs, extensions, etc. via `data_files` (in wheels).

There is a small number of common cases where default data_files and sys.prefix disagree (OS X, Debian), which is the reasoning behind asking distutils instead of hardcoding sys.prefix. When they disagree, sys.prefix is also added to paths, but we could consider not doing that. In envs (virtualenv, conda, custom Python install), these never disagree.

Unfortunately, neither Python nor distutils has a reasonable INSTALL_PREFIX API to ask for where files would go, so building a distutils object seems to be the only way to get the answer to this question.

cc @jdemeyer @takluyver @ellisonbg