### PR TITLE
Fix encoding declaration of test_migrate.py

### DIFF
--- a/jupyter_core/tests/test_migrate.py
+++ b/jupyter_core/tests/test_migrate.py
@@ -1,7 +1,7 @@
-"""Test config file migration"""
 # coding: utf-8
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
+"""Test config file migration"""
 
 import os
 import re


### PR DESCRIPTION
So it does not break with Python 2.7