### PR TITLE
Properly set PATH when `jupyter` is called from a symlink

### DIFF
--- a/jupyter_core/command.py
+++ b/jupyter_core/command.py
@@ -106,17 +106,20 @@ def _execvp(cmd, argv):
 
 def _path_with_self():
     """Ensure `jupyter`'s dir is on PATH"""
-    script = sys.argv[0]
-    bindir = os.path.dirname(script)
+    scripts = [sys.argv[0]]
+    if os.path.islink(scripts[0]):
+        scripts.append(os.path.realpath(scripts[0]))
+    bindirs = [os.path.dirname(script) for script in scripts]
     path_list = (os.environ.get('PATH') or os.defpath).split(os.pathsep)
-    if (os.path.isdir(bindir)
-        and bindir not in path_list
-        and os.access(script, os.X_OK) # only if it's a script
-    ):
-        # ensure executable's dir is on PATH
-        # avoids missing subcommands when jupyter is run via absolute path
-        path_list.append(bindir)
-        os.environ['PATH'] = os.pathsep.join(path_list)
+    for bindir, script in zip(bindirs, scripts):
+        if (os.path.isdir(bindir)
+            and bindir not in path_list
+            and os.access(script, os.X_OK) # only if it's a script
+        ):
+            # ensure executable's dir is on PATH
+            # avoids missing subcommands when jupyter is run via absolute path
+            path_list.append(bindir)
+            os.environ['PATH'] = os.pathsep.join(path_list)
     return path_list
 
 

--- a/jupyter_core/command.py
+++ b/jupyter_core/command.py
@@ -109,9 +109,9 @@ def _path_with_self():
     scripts = [sys.argv[0]]
     if os.path.islink(scripts[0]):
         scripts.append(os.path.realpath(scripts[0]))
-    bindirs = [os.path.dirname(script) for script in scripts]
     path_list = (os.environ.get('PATH') or os.defpath).split(os.pathsep)
-    for bindir, script in zip(bindirs, scripts):
+    for script in scripts:
+        bindir = os.path.dirname(script)
         if (os.path.isdir(bindir)
             and bindir not in path_list
             and os.access(script, os.X_OK) # only if it's a script
@@ -119,7 +119,7 @@ def _path_with_self():
             # ensure executable's dir is on PATH
             # avoids missing subcommands when jupyter is run via absolute path
             path_list.append(bindir)
-            os.environ['PATH'] = os.pathsep.join(path_list)
+    os.environ['PATH'] = os.pathsep.join(path_list)
     return path_list
 
 


### PR DESCRIPTION
When calling `jupyter` that was installed inside a virtual environment while that environment is not active, it is unable to locate the other executables, like `jupyter-notebook` because `execvp` uses `$PATH` instead of `sys.path` to locate the executable. `sys.path` is automatically updated by the Python interpreter to add the path to the virtual environment binaries and libraries and `$PATH` is not.

This change prepends the `$PATH` environment variable with the first entry from `sys.path` before calling `execvp` to rectify this.

NOTE: I am unfamiliar with Windows' handling of environment variables and its path, so the Windows case should be updated as well before this is merged.