### PR TITLE
[proposal] Prioritize jupyter script directory for subcommands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ __pycache__
 .#*
 .coverage
 htmlcov
+.cache

--- a/jupyter_core/command.py
+++ b/jupyter_core/command.py
@@ -105,20 +105,26 @@ def _execvp(cmd, argv):
 
 
 def _path_with_self():
-    """Ensure `jupyter`'s dir is on PATH"""
+    """Put `jupyter`'s dir at the front of PATH
+    
+    Ensures that /path/to/jupyter subcommand
+    will do /path/to/jupyter-subcommand
+    even if /other/jupyter-subcommand is ahead of it on PATH
+    """
     scripts = [sys.argv[0]]
     if os.path.islink(scripts[0]):
+        # include realpath, if `jupyter` is a symlink
         scripts.append(os.path.realpath(scripts[0]))
+
     path_list = (os.environ.get('PATH') or os.defpath).split(os.pathsep)
     for script in scripts:
         bindir = os.path.dirname(script)
         if (os.path.isdir(bindir)
-            and bindir not in path_list
             and os.access(script, os.X_OK) # only if it's a script
         ):
             # ensure executable's dir is on PATH
             # avoids missing subcommands when jupyter is run via absolute path
-            path_list.append(bindir)
+            path_list.insert(0, bindir)
     os.environ['PATH'] = os.pathsep.join(path_list)
     return path_list
 

--- a/jupyter_core/tests/test_command.py
+++ b/jupyter_core/tests/test_command.py
@@ -115,3 +115,26 @@ def test_not_on_path(tmpdir):
     witness.chmod(0o700)
     out = check_output([sys.executable, str(jupyter), 'witness'], env={'PATH': ''})
     assert b'WITNESS' in out
+
+
+def test_path_priority(tmpdir):
+    a = tmpdir.mkdir("a")
+    jupyter = a.join('jupyter')
+    jupyter.write(
+        'from jupyter_core import command; command.main()'
+    )
+    jupyter.chmod(0o700)
+    witness_cmd = 'jupyter-witness'
+    if sys.platform == 'win32':
+        witness_cmd += '.py'
+    witness_a = a.join(witness_cmd)
+    witness_a.write('#!%s\n%s\n' % (sys.executable, 'print("WITNESS A")'))
+    witness_a.chmod(0o700)
+
+    b = tmpdir.mkdir("b")
+    witness_b = b.join(witness_cmd)
+    witness_b.write('#!%s\n%s\n' % (sys.executable, 'print("WITNESS B")'))
+    witness_b.chmod(0o700)
+
+    out = check_output([sys.executable, str(jupyter), 'witness'], env={'PATH': str(b)})
+    assert b'WITNESS A' in out


### PR DESCRIPTION
ensure that `/path/to/jupyter-subcommand` has top priority when `/path/to/jupyter subcommand` is called.