### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,7 +3,7 @@ jupyter_core |version|
 
 This documentation only describes the public API in the ``jupyter_core``
 package. For overview information about using Jupyter, see the `main Jupyter
-docs <http://jupyter.readthedocs.org/en/latest/>`__.
+docs <https://jupyter.readthedocs.io/en/latest/>`__.
 
 Contents:
 


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.