### PR TITLE
More informative error message if _execvp fails

### DIFF
--- a/jupyter_core/command.py
+++ b/jupyter_core/command.py
@@ -185,9 +185,7 @@ def main():
     try:
         _execvp(command, sys.argv[1:])
     except OSError as e:
-        if e.errno == errno.ENOENT:
-            sys.exit("jupyter: %r is not a Jupyter command" % subcommand)
-        raise
+        sys.exit("Error executing Jupyter command %r: %s" % (subcommand, e))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
It happened more than once that the error message of a failing `_execvp` was unclear to me. This branch helps that.