### PR TITLE
Add environment variable to ignore all config

### DIFF
--- a/jupyter_core/paths.py
+++ b/jupyter_core/paths.py
@@ -24,6 +24,18 @@ def get_home_dir():
     homedir = os.path.realpath(homedir)
     return homedir
 
+_dtemps = {}
+def _mkdtemp_once(name):
+    """Make or reuse a temporary directory.
+
+    If this is called with the same name in the same process, it will return
+    the same directory.
+    """
+    try:
+        return _dtemps[name]
+    except KeyError:
+        d = _dtemps[name] = tempfile.mkdtemp(prefix=name + '-')
+        return d
 
 def jupyter_config_dir():
     """Get the Jupyter config directory for this platform and user.
@@ -35,7 +47,7 @@ def jupyter_config_dir():
     home_dir = get_home_dir()
 
     if env.get('JUPYTER_NO_CONFIG'):
-        return tempfile.mkdtemp(prefix='jupyter-clean-cfg-')
+        return _mkdtemp_once('jupyter-clean-cfg')
 
     if env.get('JUPYTER_CONFIG_DIR'):
         return env['JUPYTER_CONFIG_DIR']

--- a/jupyter_core/paths.py
+++ b/jupyter_core/paths.py
@@ -11,6 +11,7 @@
 
 import os
 import sys
+import tempfile
 
 pjoin = os.path.join
 
@@ -32,6 +33,9 @@ def jupyter_config_dir():
 
     env = os.environ
     home_dir = get_home_dir()
+
+    if env.get('JUPYTER_NO_CONFIG'):
+        return tempfile.mkdtemp(prefix='jupyter-clean-cfg-')
 
     if env.get('JUPYTER_CONFIG_DIR'):
         return env['JUPYTER_CONFIG_DIR']
@@ -164,6 +168,9 @@ ENV_CONFIG_PATH = [os.path.join(sys.prefix, 'etc', 'jupyter')]
 def jupyter_config_path():
     """Return the search path for Jupyter config files as a list."""
     paths = [jupyter_config_dir()]
+    if os.environ.get('JUPYTER_NO_CONFIG'):
+        return paths
+
     for p in ENV_CONFIG_PATH:
         if p not in SYSTEM_CONFIG_PATH:
             paths.append(p)


### PR DESCRIPTION
Setting JUPYTER_NO_CONFIG=1 will ignore all custom config. I'm using the convention of taking any non-empty value as True.

Closes jupyter/notebook#1992

I also considered that maybe this should ignore anything in the data search path as well (in which case, the environment variable may need a different name). However, while nbextensions are installed in data
files, they are only loaded if they are enabled in config, so I think this should avoid loading them. We may still want to make it affect the data path too for future-proofing.