### PR TITLE
Prepare to release 4.3

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,19 @@
 Changes in jupyter-core
 =======================
 
+4.3
+---
+
+4.3.0
+~~~~~
+
+`on
+GitHub <https://github.com/jupyter/jupyter_core/releases/tag/4.3.0>`__
+
+- Add `JUPYTER_NO_CONFIG` environment variable for disabling all Jupyter configuration.
+- More detailed error message when failing to launch subcommands.
+
+
 4.2
 ---
 


### PR DESCRIPTION
Tiny release:

- adds JUPYTER_NO_CONFIG
- tweak error message when no subcommand is found