### PR TITLE
[zsh-completion] copy&paste mistake in description

### DIFF
--- a/examples/completions-zsh
+++ b/examples/completions-zsh
@@ -186,7 +186,7 @@ _notebook_cmds() {
     'help:Print help about subcommand.'
     'list:List currently running notebook servers in this profile.'
   )
-  _describe -t commands 'nbextension command' commands "$@"
+  _describe -t commands 'notebook command' commands "$@"
 }
 
 _jupyter "$@"


### PR DESCRIPTION
when tab completing "jupyter notebook <TAB>" the completion suggestions should be titled "notebook command" rather than "nbextension command"