### PR TITLE
use sys.executable for pip list

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,15 @@
 language: python
 sudo: false
 python:
-    - 3.5
-    - 3.4
-    - 3.3
-    - 2.7
+  - nightly
+  - 3.6
+  - 3.5
+  - 3.4
+  - 3.3
+  - 2.7
 before_install:
-    - git clone --quiet --depth 1 https://github.com/minrk/travis-wheels travis-wheels
+  - pip install --upgrade setuptools pip
 install:
-    - pip install -f travis-wheels/wheelhouse -r dev-requirements.txt .
+  - pip install -r dev-requirements.txt .
 script:
-    - py.test jupyter_core
+  - py.test jupyter_core

--- a/jupyter_core/troubleshoot.py
+++ b/jupyter_core/troubleshoot.py
@@ -45,7 +45,7 @@ def get_data():
     else:
         env['which'] = subs(['which', '-a', 'jupyter'])
         env['where'] = None
-    env['pip'] = subs(['pip', 'list'])
+    env['pip'] = subs([sys.executable, '-m', 'pip', 'list'])
     env['conda'] = subs(['conda', 'list'])
     return env
 


### PR DESCRIPTION
avoids reporting `pip list` for a different env (e.g. Python 2)