### PR TITLE
Depend on ipykernel instead of ipython

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,3 @@
 pytest
 mock
-ipython
+ipykernel


### PR DESCRIPTION
I verified that the unit tests require neither ipython nor ipykernel. According to the discussion in #99, it makes sense to have a dependency in ipykernel though, for manual testing.

I also verified that the doc build does not depend on ipython.

Does not quite resolve #99... there is still a circular dependency, though not via `ipython` anymore.