### PR TITLE
Fix broken link in changelog

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -52,7 +52,7 @@ GitHub <https://github.com/jupyter/jupyter_core/releases/tag/4.1.1>`__
 ~~~~~
 
 `on
-GitHub <https://github.com/jupyter/jupyter_core/releases/tag/4.1>`__
+GitHub <https://github.com/jupyter/jupyter_core/releases/tag/4.1.0>`__
 
 - Add ``jupyter.py`` module, so that :command:`python -m jupyter` always works.
 - Add prototype ``jupyter troubleshoot`` command for displaying environment info.


### PR DESCRIPTION
`make linkcheck` in the `docs/` dir reports a broken link to the release tag 4.1. The release is tagged as 4.1.0.