### PR TITLE
Use standard locations for environment path

### DIFF
--- a/jupyter_core/paths.py
+++ b/jupyter_core/paths.py
@@ -174,7 +174,10 @@ else:
         "/etc/jupyter",
     ]
 
-ENV_CONFIG_PATH = [os.path.join(sys.prefix, 'etc', 'jupyter')]
+if os.name != 'nt' and sys.prefix == '/usr':
+    ENV_CONFIG_PATH = SYSTEM_CONFIG_PATH
+else:
+    ENV_CONFIG_PATH = [os.path.join(sys.prefix, 'etc', 'jupyter')]
 
 
 def jupyter_config_path():


### PR DESCRIPTION
When using `data_files` in `setup.py`, files are stored in `/usr/local`.  

cf https://github.com/jupyterlab/jupyterlab/issues/3105