### PR TITLE
Avoid triggering extra logic in IPython.paths.get_ipython_dir when performing migration

### DIFF
--- a/jupyter_core/application.py
+++ b/jupyter_core/application.py
@@ -160,10 +160,9 @@ class JupyterApp(Application):
             return
 
         from .migrate import get_ipython_dir, migrate
-        
-        ipdir = get_ipython_dir()
+
         # No IPython dir, nothing to migrate
-        if not os.path.exists(ipdir):
+        if not os.path.exists(get_ipython_dir()):
             return
 
         migrate()

--- a/jupyter_core/migrate.py
+++ b/jupyter_core/migrate.py
@@ -31,15 +31,6 @@ from traitlets.config import PyFileConfigLoader, JSONFileConfigLoader
 from traitlets.log import get_logger
 
 from .utils import ensure_dir_exists
-try:
-    from IPython.paths import get_ipython_dir
-except ImportError:
-    # IPython < 4
-    try:
-        from IPython.utils.path import get_ipython_dir
-    except ImportError:
-        def get_ipython_dir():
-            return os.environ.get('IPYTHONDIR', os.path.expanduser('~/.ipython'))
 
 from .paths import jupyter_config_dir, jupyter_data_dir
 from .application import JupyterApp
@@ -71,6 +62,21 @@ config_substitutions = {
     regex(r'\bIPython\.html\b'): 'notebook',
     regex(r'\bIPython\.nbconvert\b'): 'nbconvert',
 }
+
+
+def get_ipython_dir():
+    """Return the IPython directory location.
+
+    Not imported from IPython because the IPython implementation
+    ensures that a writable directory exists,
+    creating a temporary directory if not.
+    We don't want to trigger that when checking if migration should happen.
+
+    We only need to support the IPython < 4 behavior for migration,
+    so importing for forward-compatibility and edge cases is not important.
+    """
+    return os.environ.get('IPYTHONDIR', os.path.expanduser('~/.ipython'))
+
 
 def migrate_dir(src, dst):
     """Migrate a directory from src to dst"""


### PR DESCRIPTION
IPython's get_ipython_dir always returns a writable directory that exists, creating one if the default resolution isn't writable.

We don't want to trigger all of this extra logic when checking for old config files to migrate,
so reimplement a simpler IPython dir resolution without any of IPython's own migration logic.

We already had a check if `get_ipython_dir()` exists to skip migration, but this would always be True because of upstream `get_ipython_dir()`'s behavior.

closes jupyterhub/jupyterhub#1503

It's also been long enough that we could consider removing automatic migration altogether, leaving only the explicit `jupyter-migrate` command.