### PR TITLE
 properly handle unicode characters in home dirs

### DIFF
--- a/jupyter_core/paths.py
+++ b/jupyter_core/paths.py
@@ -21,7 +21,7 @@ def get_home_dir():
     homedir = os.path.expanduser('~')
     # Next line will make things work even when /home/ is a symlink to
     # /usr/home as it is on FreeBSD, for example
-    homedir = os.path.realpath(homedir)
+    homedir = os.path.realpath(homedir).decode(sys.getfilesystemencoding())
     return homedir
 
 _dtemps = {}


### PR DESCRIPTION
Sometimes users have home directories that contain unicode characters outside of ASCII (such as č). This leads to exception thrown in `migrate.py:migrate` namely in the line:
`        dst = dst_t.format(**env)`
because `jupyter_config_dir` and `jupyter_data_dir` do not return unicode. 