### PR TITLE
 properly handle unicode characters in home dirs

### DIFF
--- a/jupyter_core/paths.py
+++ b/jupyter_core/paths.py
@@ -22,7 +22,8 @@ def get_home_dir():
     homedir = os.path.expanduser('~')
     # Next line will make things work even when /home/ is a symlink to
     # /usr/home as it is on FreeBSD, for example
-    home = py3compat.str_to_unicode(os.path.expanduser('~'), encoding=sys.getfilesystemencoding()) 
+    homedir = os.path.realpath(homedir)
+    homedir = py3compat.str_to_unicode(homedir, encoding=sys.getfilesystemencoding()) 
     return homedir
 
 _dtemps = {}

--- a/jupyter_core/paths.py
+++ b/jupyter_core/paths.py
@@ -12,6 +12,7 @@
 import os
 import sys
 import tempfile
+from ipython_genutils import py3compat
 
 pjoin = os.path.join
 
@@ -21,7 +22,7 @@ def get_home_dir():
     homedir = os.path.expanduser('~')
     # Next line will make things work even when /home/ is a symlink to
     # /usr/home as it is on FreeBSD, for example
-    homedir = os.path.realpath(homedir)
+    home = py3compat.str_to_unicode(os.path.expanduser('~'), encoding=sys.getfilesystemencoding()) 
     return homedir
 
 _dtemps = {}


### PR DESCRIPTION
Sometimes users have home directories that contain unicode characters outside of ASCII (such as č). This leads to exception thrown in `migrate.py:migrate` namely in the line:
`        dst = dst_t.format(**env)`
because `jupyter_config_dir` and `jupyter_data_dir` do not return unicode. 