### PR TITLE
 properly handle unicode characters in home dirs v2

### DIFF
--- a/jupyter_core/paths.py
+++ b/jupyter_core/paths.py
@@ -22,6 +22,8 @@ def get_home_dir():
     # Next line will make things work even when /home/ is a symlink to
     # /usr/home as it is on FreeBSD, for example
     homedir = os.path.realpath(homedir)
+    if sys.version_info.major == 2: # on Python 2 we need to convert to unicode
+        homedir = homedir.decode(sys.getfilesystemencoding())
     return homedir
 
 _dtemps = {}


### PR DESCRIPTION
Sometimes users have home directories that contain unicode characters outside of ASCII (such as č). This leads to exception thrown in `migrate.py:migrate` namely in the line:
`        dst = dst_t.format(**env)`
because `jupyter_config_dir` and `jupyter_data_dir` do not return unicode. 

Since my prevous pull request is failing tests due to `future` not being installed I've created alternative version.