### PR TITLE
Print multiple package version when using jupyter --version.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,8 @@ python:
   - 3.3
   - 2.7
 before_install:
-  - pip install --upgrade setuptools pip
+  - pip install --upgrade pip
+  - pip install --upgrade setuptools
 install:
   - pip install -r dev-requirements.txt .
 script:

--- a/jupyter_core/application.py
+++ b/jupyter_core/application.py
@@ -65,7 +65,7 @@ class JupyterApp(Application):
     
     aliases = base_aliases
     flags = base_flags
-    
+
     def _log_level_default(self):
         return logging.INFO
     

--- a/jupyter_core/command.py
+++ b/jupyter_core/command.py
@@ -149,7 +149,28 @@ def main():
         args, opts = parser.parse_known_args()
         subcommand = args.subcommand
         if args.version:
-            print(__version__)
+            print('{:<17}:'.format('jupyter core'), __version__)
+            for  package, name in [
+                ('notebook', 'jupyter-notebook'),
+                ('qtconsole', 'qtconsole'),
+                ('IPython', 'ipython'),
+                ('ipykernel', 'ipykernel'),
+                ('jupyter_client', 'jupyter client'),
+                ('jupyterlab', 'jupyter lab'),
+                ('nbconvert', 'nbconvert'),
+                ('ipywidgets', 'ipywidgets'),
+                ('nbformat', 'nbformat'),
+                ('traitlets', 'traitlets'),
+            ]:
+                version = None
+                try:
+                    mod = __import__(package)
+                    version = mod.__version__
+                except ImportError:
+                    version = 'not installed'
+                print('{:<17}:'.format(name), version)
+
+
             return
         if args.json and not args.paths:
             sys.exit("--json is only used with --paths")


### PR DESCRIPTION
Many users use `jupyter --version` and then report they have "jupyter
4.4" which make no sens. Instead of printing an number and existing,
print a list.

That may break people shelling you to actually get jupyter_core version,
but I believe giving users the right information is more important
