### PR TITLE
Enable system-wide installations of Jupyter possible at any path

### DIFF
--- a/jupyter_core/paths.py
+++ b/jupyter_core/paths.py
@@ -183,6 +183,14 @@ def jupyter_config_path():
     if os.environ.get('JUPYTER_NO_CONFIG'):
         return paths
 
+    # highest priority is env
+    if os.environ.get('JUPYTER_CONFIG_PATH'):
+        paths.extend(
+            p.rstrip(os.sep)
+            for p in os.environ['JUPYTER_CONFIG_PATH'].split(os.pathsep)
+        )
+
+    # then sys.prefix
     for p in ENV_CONFIG_PATH:
         if p not in SYSTEM_CONFIG_PATH:
             paths.append(p)


### PR DESCRIPTION
Extend the config paths with additional system paths from environment variable JUPYTER_CONFIG_PATH.

Motivation:
Currently Jupyter configurations are only searched at fixed system paths (sys.prefix/etc/jupyter, ...)
and jupyter_config_dir(), which is in the first place a config dir writable to the user.
For a system-wide installation of Jupyter, which is not installed at sys.prefix one needs to have the ability to add additional system config paths.