### PR TITLE
Remove useless code

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,19 +31,6 @@ version_ns = {}
 with open(pjoin(here, 'jupyter_core', 'version.py')) as f:
     exec(f.read(), {}, version_ns)
 
-def find_package_data():
-    """Find package data (testing support files)"""
-    package_data = {}
-    package_data['jupyter_core.tests'] = test_files = []
-    test_dir = pjoin('jupyter_core', 'tests')
-    prefix_len = len(test_dir) + len(os.sep)
-    for parent, dirs, files in os.walk(test_dir):
-        if files:
-            test_files.append(pjoin(parent[prefix_len:], '*.*'))
-    
-    return package_data
-
-package_data = find_package_data()
 
 setup_args = dict(
     name                = 'jupyter_core',
@@ -52,7 +39,6 @@ setup_args = dict(
                            'jupyter_core.utils',
                            'jupyter_core.tests'],
     py_modules          = ['jupyter'],
-    package_data        = package_data,
     scripts             = glob(pjoin('scripts', '*')),
     description         = "Jupyter core package. A base package on which Jupyter projects rely.",
     long_description    = """There is no reason to install this package on its own.""",


### PR DESCRIPTION
While investigating https://github.com/jupyter/jupyter_core/issues/120 I learned that this code is not needed. Without this code the same wheel is created.

If any of the packages contain a `__pycache__` then it will be included in the wheel.

I'm not sure how the `__pycache__` was created though. I tried installing the package and running tox and there was no `__pycache__` created.