### PR TITLE
Stop using XDG_RUNTIME_DIR

### DIFF
--- a/jupyter_core/paths.py
+++ b/jupyter_core/paths.py
@@ -90,24 +90,15 @@ def jupyter_runtime_dir():
     
     Returns JUPYTER_RUNTIME_DIR if defined.
     
-    Respects XDG_RUNTIME_DIR on non-OS X, non-Windows,
-    falls back on data_dir/runtime otherwise.
+    The default is now (data_dir)/runtime on all platforms;
+    we no longer use XDG_RUNTIME_DIR after various problems.
     """
     env = os.environ
     
     if env.get('JUPYTER_RUNTIME_DIR'):
         return env['JUPYTER_RUNTIME_DIR']
-    
-    if sys.platform == 'darwin':
-        return pjoin(jupyter_data_dir(), 'runtime')
-    elif os.name == 'nt':
-        return pjoin(jupyter_data_dir(), 'runtime')
-    else:
-        # Linux, non-OS X Unix, AIX, etc.
-        xdg = env.get("XDG_RUNTIME_DIR", None)
-        if xdg:
-            return pjoin(xdg, 'jupyter')
-        return pjoin(jupyter_data_dir(), 'runtime')
+
+    return pjoin(jupyter_data_dir(), 'runtime')
 
 
 if os.name == 'nt':


### PR DESCRIPTION
After years of trying to make this work, I've reluctantly come to the conclusion that XDG_RUNTIME_DIR is, for us, more trouble than it's worth.

Three problems in particular have led to this:

1. When Jupyter runs as a server, e.g. with screen or nohup, XDG_RUNTIME_DIR can be deleted from under us if the user logs out. I haven't found any good way to prevent this.
2. The spec allows files to be automatically cleaned up after a few hours. In theory this can be prevented by setting the sticky bit, but it's not clear where it needs to be set, and we can't be sure that all systems actually respect that.
3. Sometimes the environment variable is automatically carried over from a context where it's accurate to a context where it's not. It's definitely not the only environment variable for which this can happen,
but since it's set at login by many modern Linux systems, it's an obvious source of problems.

Set against this, the benefits of XDG_RUNTIME_DIR:

- The system should ensure that it is readable and writable only to the user who owns it. It doesn't save us any complexity, because we still try to make the same guarantees on platforms without XDG_RUNTIME_DIR, but it's nice to have an extra backstop against oversights by us or by our users.
- It's reset on each boot, so if kernels or servers crash and don't clean up their connection files, those files don't last forever. It's nice to have, but again, we need to cope with leftover files for other
platforms.
- You can reliably use XDG_RUNTIME_DIR for objects like named pipes and Unix sockets, because it's guaranteed not to be on NFS. We do have an option to use Unix sockets for ZMQ connections, but as far as I know, it's rarely used. We can find other ways to use it for that specific purpose if necessary.