### PR TITLE
Always use setuptools in setup.py

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,37 @@
+[metadata]
+name             = jupyter_core
+version          = attr: jupyter_core.version.__version__
+description      = Jupyter core package. A base package on which Jupyter projects rely.
+long_description = There is no reason to install this package on its own.
+author           = Jupyter Development Team
+author_email     = jupyter@googlegroups.org
+url              = https://jupyter.org
+license          = BSD
+classifiers      =
+    Intended Audience :: Developers
+    Intended Audience :: System Administrators
+    Intended Audience :: Science/Research
+    License :: OSI Approved :: BSD License
+    Programming Language :: Python
+    Programming Language :: Python :: 2
+    Programming Language :: Python :: 2.7
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.3
+    Programming Language :: Python :: 3.4
+
+[options]
+py_modules = jupyter
+packages = jupyter_core, jupyter_core.utils, jupyter_core.tests
+include_package_data = True
+python_requires = >=2.7, !=3.0, !=3.1, !=3.2
+install_requires =
+    traitlets
+
+[options.entry_points]
+console_scripts =
+    jupyter              = jupyter_core.command:main
+    jupyter-migrate      = jupyter_core.migrate:main
+    jupyter-troubleshoot = jupyter_core.troubleshoot:main
+
 [bdist_wheel]
 universal=1

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,24 @@
 
 # Copyright (c) Juptyer Development Team.
 # Distributed under the terms of the Modified BSD License.
+import sys
 from setuptools import setup
+from setuptools.command.bdist_egg import bdist_egg
+
+
+class bdist_egg_disabled(bdist_egg):
+    """Disabled version of bdist_egg
+
+    Prevents setup.py install from performing setuptools' default easy_install,
+    which it should never ever do.
+    """
+    def run(self):
+        sys.exit("Aborting implicit building of eggs. Use `pip install .` to install from source.")
+
 
 # Loads metadata and options from setup.cfg:
-setup()
+setup(
+    cmdclass={
+        'bdist_egg': bdist_egg if 'bdist_egg' in sys.argv else bdist_egg_disabled,
+    },
+)

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ if v[:2] < (2,7) or (v[:2] > (3,) and v[:2] < (3,3)):
 
 # At least we're on the python version we need, move on.
 
-from distutils.core import setup
+from setuptools import setup
 
 pjoin = os.path.join
 here = os.path.abspath(os.path.dirname(__file__))
@@ -53,7 +53,6 @@ setup_args = dict(
                            'jupyter_core.tests'],
     py_modules          = ['jupyter'],
     package_data        = package_data,
-    scripts             = glob(pjoin('scripts', '*')),
     description         = "Jupyter core package. A base package on which Jupyter projects rely.",
     long_description    = """There is no reason to install this package on its own.""",
     author              = "Jupyter Development Team",
@@ -72,29 +71,15 @@ setup_args = dict(
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
     ],
-)
-
-if any(arg.startswith('bdist') for arg in sys.argv):
-    import setuptools
-
-setuptools_args = {}
-
-setuptools_args['install_requires'] = [
-    'traitlets',
-]
-
-setuptools_args['entry_points'] = {
-    'console_scripts': [
+    install_requires    = [
+        'traitlets',
+    ],
+    console_scripts     = [
         'jupyter = jupyter_core.command:main',
         'jupyter-migrate = jupyter_core.migrate:main',
         'jupyter-troubleshoot = jupyter_core.troubleshoot:main',
-    ]
-}
-
-# setuptools requirements
-if 'setuptools' in sys.modules:
-    setup_args.update(setuptools_args)
-    setup_args.pop('scripts', None)
+    ],
+)
 
 
 if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -4,21 +4,7 @@
 # Copyright (c) Juptyer Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-#-----------------------------------------------------------------------------
-# Minimal Python version sanity check (from IPython)
-#-----------------------------------------------------------------------------
-from __future__ import print_function
-
 import os
-import sys
-
-v = sys.version_info
-if v[:2] < (2,7) or (v[:2] > (3,) and v[:2] < (3,3)):
-    error = "ERROR: Jupyter requires Python version 2.7 or 3.3 or above."
-    print(error, file=sys.stderr)
-    sys.exit(1)
-
-# At least we're on the python version we need, move on.
 
 from setuptools import setup
 
@@ -55,6 +41,7 @@ setup_args = dict(
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
     ],
+    python_requires     = '>=2.7, !=3.0, !=3.1, !=3.2',
     install_requires    = [
         'traitlets',
     ],

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,6 @@ from __future__ import print_function
 
 import os
 import sys
-from glob import glob
 
 v = sys.version_info
 if v[:2] < (2,7) or (v[:2] > (3,) and v[:2] < (3,3)):
@@ -31,20 +30,6 @@ version_ns = {}
 with open(pjoin(here, 'jupyter_core', 'version.py')) as f:
     exec(f.read(), {}, version_ns)
 
-def find_package_data():
-    """Find package data (testing support files)"""
-    package_data = {}
-    package_data['jupyter_core.tests'] = test_files = []
-    test_dir = pjoin('jupyter_core', 'tests')
-    prefix_len = len(test_dir) + len(os.sep)
-    for parent, dirs, files in os.walk(test_dir):
-        if files:
-            test_files.append(pjoin(parent[prefix_len:], '*.*'))
-    
-    return package_data
-
-package_data = find_package_data()
-
 setup_args = dict(
     name                = 'jupyter_core',
     version             = version_ns['__version__'],
@@ -52,7 +37,6 @@ setup_args = dict(
                            'jupyter_core.utils',
                            'jupyter_core.tests'],
     py_modules          = ['jupyter'],
-    package_data        = package_data,
     description         = "Jupyter core package. A base package on which Jupyter projects rely.",
     long_description    = """There is no reason to install this package on its own.""",
     author              = "Jupyter Development Team",
@@ -79,6 +63,7 @@ setup_args = dict(
         'jupyter-migrate = jupyter_core.migrate:main',
         'jupyter-troubleshoot = jupyter_core.troubleshoot:main',
     ],
+    include_package_data = True,
 )
 
 

--- a/setup.py
+++ b/setup.py
@@ -3,56 +3,7 @@
 
 # Copyright (c) Juptyer Development Team.
 # Distributed under the terms of the Modified BSD License.
-
-import os
-
 from setuptools import setup
 
-pjoin = os.path.join
-here = os.path.abspath(os.path.dirname(__file__))
-
-# Get the current package version.
-version_ns = {}
-with open(pjoin(here, 'jupyter_core', 'version.py')) as f:
-    exec(f.read(), {}, version_ns)
-
-setup_args = dict(
-    name                = 'jupyter_core',
-    version             = version_ns['__version__'],
-    packages            = ['jupyter_core',
-                           'jupyter_core.utils',
-                           'jupyter_core.tests'],
-    py_modules          = ['jupyter'],
-    description         = "Jupyter core package. A base package on which Jupyter projects rely.",
-    long_description    = """There is no reason to install this package on its own.""",
-    author              = "Jupyter Development Team",
-    author_email        = "jupyter@googlegroups.org",
-    url                 = "https://jupyter.org",
-    license             = "BSD",
-    classifiers         = [
-        'Intended Audience :: Developers',
-        'Intended Audience :: System Administrators',
-        'Intended Audience :: Science/Research',
-        'License :: OSI Approved :: BSD License',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
-    ],
-    python_requires     = '>=2.7, !=3.0, !=3.1, !=3.2',
-    install_requires    = [
-        'traitlets',
-    ],
-    console_scripts     = [
-        'jupyter = jupyter_core.command:main',
-        'jupyter-migrate = jupyter_core.migrate:main',
-        'jupyter-troubleshoot = jupyter_core.troubleshoot:main',
-    ],
-    include_package_data = True,
-)
-
-
-if __name__ == '__main__':
-    setup(**setup_args)
+# Loads metadata and options from setup.cfg:
+setup()


### PR DESCRIPTION
Now that there are universal wheels, the setup.py is usually only ever
executed on a developer machine, where one can assume setuptools to be
available.

This slightly simplifies the setup.py code and results less potential
surprises between different setup.py runs (i.e. what happens if you run
`setup.py install` versus `setup.py bdist_wheel` and then install).

This also contains an alternate resolution for #120.

My recommendation would be to favour this PR over #146, but I can understand if you have concerns.

Best, Thomas

Resolves #120.
Closes #146.