### PR TITLE
Respect the raise_config_file_errors trait and re-raise if applicable.

### DIFF
--- a/jupyter_core/application.py
+++ b/jupyter_core/application.py
@@ -203,8 +203,9 @@ class JupyterApp(Application):
         except ConfigFileNotFound:
             self.log.debug("Config file not found, skipping: %s", config_file_name)
         except Exception:
-            # For testing purposes.
-            if not suppress_errors:
+            # Reraise errors for testing purposes, or if set in
+            # self.raise_config_file_errors
+            if not suppress_errors or self.raise_config_file_errors:
                 raise
             self.log.warning("Error loading config file: %s" %
                             config_file_name, exc_info=True)

--- a/jupyter_core/application.py
+++ b/jupyter_core/application.py
@@ -205,7 +205,7 @@ class JupyterApp(Application):
         except Exception:
             # Reraise errors for testing purposes, or if set in
             # self.raise_config_file_errors
-            if not suppress_errors or self.raise_config_file_errors:
+            if (not suppress_errors) or self.raise_config_file_errors:
                 raise
             self.log.warning("Error loading config file: %s" %
                             config_file_name, exc_info=True)

--- a/jupyter_core/tests/test_application.py
+++ b/jupyter_core/tests/test_application.py
@@ -94,3 +94,17 @@ def test_load_config():
     shutil.rmtree(config_dir)
     shutil.rmtree(wd)
 
+def test_load_bad_config():
+    config_dir = mkdtemp()
+    wd = mkdtemp()
+    with open(pjoin(config_dir, 'dummy_app_config.py'), 'w') as f:
+        f.write('c.DummyApp.m = "a\n') # Syntax error
+    with patch.object(py3compat, 'getcwd', lambda : wd):
+        with pytest.raises(SyntaxError):
+            app = DummyApp(config_dir=config_dir)
+            app.raise_config_file_errors=True
+            app.initialize([])
+
+    shutil.rmtree(config_dir)
+    shutil.rmtree(wd)
+


### PR DESCRIPTION
I was taking a look at jupyterlab/jupyterlab#5716, and found that setting the base `Application` trait `raise_config_file_errors` wasn't behaving as I expected. This is because `JupyterApp` overloads the `load_config_file` function and doesn't check this option.

A quick audit of the Jupyter ecosystem shows that there are a couple of different behaviors around this.
* [`jupyterhub`](https://github.com/jupyterhub/jupyterhub/commit/7968912a7c6dda77472af15230bf6ae40e3324b2) inherits from `Application` rather than `JupyterApp`, so the trait works as expected.
* [`IPython`](https://github.com/ipython/traitlets/pull/228) overrides `load_config_file`, and specifically checks for this option.
* Notebook and JupyterLab inherit from `JupyterApp`, and they do not respect this option.

Another option would be to override the `load_config_file` option in lab/notebook, but it seemed cleaner to me to add this check here.