### PR TITLE
Drop Python 3.3 from Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,10 @@ language: python
 sudo: false
 python:
   - nightly
-  - 3.6
-  - 3.5
-  - 3.4
-  - 3.3
-  - 2.7
+  - "3.6"
+  - "3.5"
+  - "3.4"
+  - "2.7"
 before_install:
   - pip install --upgrade pip
   - pip install --upgrade setuptools


### PR DESCRIPTION
Even 3.4 is nearly EOL, and infrastructure like pip has dropped 3.3 support already.

Also quoted the other entries to make them strings, because my IDE was complaining that the list mixed strings and numbers.