### PR TITLE
Require mock only for running tests on Python 2

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,3 @@
 pytest
-mock
+mock; python_version < '3.3'
 ipykernel


### PR DESCRIPTION
All usages of mock are inside "except ImportError" branches meant for
running tests under Python 2. There is no need to install mock when using Python 3.