### PR TITLE
Fix deprecation warning from traitlets

### DIFF
--- a/jupyter_core/application.py
+++ b/jupyter_core/application.py
@@ -29,7 +29,7 @@ except NameError:
 
 from traitlets.config.application import Application, catch_config_error
 from traitlets.config.loader import ConfigFileNotFound
-from traitlets import Unicode, Bool, List
+from traitlets import Unicode, Bool, List, observe
 
 from .utils import ensure_dir_exists
 from ipython_genutils import py3compat
@@ -98,10 +98,11 @@ class JupyterApp(Application):
         rd = jupyter_runtime_dir()
         ensure_dir_exists(rd, mode=0o700)
         return rd
-    
-    def _runtime_dir_changed(self, new):
-        ensure_dir_exists(new, mode=0o700)
-    
+
+    @observe('runtime_dir')
+    def _runtime_dir_changed(self, change):
+        ensure_dir_exists(change['new'], mode=0o700)
+
     generate_config = Bool(False, config=True,
         help="""Generate default config file."""
     )

--- a/jupyter_core/tests/test_application.py
+++ b/jupyter_core/tests/test_application.py
@@ -94,6 +94,7 @@ def test_load_config():
     shutil.rmtree(config_dir)
     shutil.rmtree(wd)
 
+
 def test_load_bad_config():
     config_dir = mkdtemp()
     wd = mkdtemp()
@@ -108,3 +109,11 @@ def test_load_bad_config():
     shutil.rmtree(config_dir)
     shutil.rmtree(wd)
 
+
+def test_runtime_dir_changed():
+    app = DummyApp()
+    td = mkdtemp()
+    shutil.rmtree(td)
+    app.runtime_dir = td
+    assert os.path.isdir(td)
+    shutil.rmtree(td)


### PR DESCRIPTION
Hello,

This PR fixes warnings like this:
 - DeprecationWarning: DummyConsoleApp._runtime_dir_changed is deprecated in traitlets 4.1: use @observe and @unobserve instead.