### PR TITLE
Moved path util code from jupyter_client and jupyter_server to core

### DIFF
--- a/jupyter_core/paths.py
+++ b/jupyter_core/paths.py
@@ -11,9 +11,18 @@
 
 import os
 import sys
+import stat
+import errno
 import tempfile
 
+from contextlib import contextmanager
+from ipython_genutils import py3compat
+
 pjoin = os.path.join
+
+# UF_HIDDEN is a stat flag not defined in the stat module.
+# It is used by BSD to indicate hidden files.
+UF_HIDDEN = getattr(stat, 'UF_HIDDEN', 32768)
 
 
 def get_home_dir():
@@ -39,7 +48,7 @@ def _mkdtemp_once(name):
 
 def jupyter_config_dir():
     """Get the Jupyter config directory for this platform and user.
-    
+
     Returns JUPYTER_CONFIG_DIR if defined, else ~/.jupyter
     """
 
@@ -51,22 +60,22 @@ def jupyter_config_dir():
 
     if env.get('JUPYTER_CONFIG_DIR'):
         return env['JUPYTER_CONFIG_DIR']
-    
+
     return pjoin(home_dir, '.jupyter')
 
 
 def jupyter_data_dir():
     """Get the config directory for Jupyter data files.
-    
+
     These are non-transient, non-configuration files.
-    
+
     Returns JUPYTER_DATA_DIR if defined, else a platform-appropriate path.
     """
     env = os.environ
-    
+
     if env.get('JUPYTER_DATA_DIR'):
         return env['JUPYTER_DATA_DIR']
-    
+
     home = get_home_dir()
 
     if sys.platform == 'darwin':
@@ -87,14 +96,14 @@ def jupyter_data_dir():
 
 def jupyter_runtime_dir():
     """Return the runtime dir for transient jupyter files.
-    
+
     Returns JUPYTER_RUNTIME_DIR if defined.
-    
+
     The default is now (data_dir)/runtime on all platforms;
     we no longer use XDG_RUNTIME_DIR after various problems.
     """
     env = os.environ
-    
+
     if env.get('JUPYTER_RUNTIME_DIR'):
         return env['JUPYTER_RUNTIME_DIR']
 
@@ -118,19 +127,19 @@ ENV_JUPYTER_PATH = [os.path.join(sys.prefix, 'share', 'jupyter')]
 
 def jupyter_path(*subdirs):
     """Return a list of directories to search for data files
-    
+
     JUPYTER_PATH environment variable has highest priority.
-    
+
     If ``*subdirs`` are given, that subdirectory will be added to each element.
-    
+
     Examples:
-    
+
     >>> jupyter_path()
     ['~/.local/jupyter', '/usr/local/share/jupyter']
     >>> jupyter_path('kernels')
     ['~/.local/jupyter/kernels', '/usr/local/share/jupyter/kernels']
     """
-    
+
     paths = []
     # highest priority is env
     if os.environ.get('JUPYTER_PATH'):
@@ -146,7 +155,7 @@ def jupyter_path(*subdirs):
             paths.append(p)
     # finally, system
     paths.extend(SYSTEM_JUPYTER_PATH)
-    
+
     # add subdir, if requested
     if subdirs:
         paths = [ pjoin(p, *subdirs) for p in paths ]
@@ -187,3 +196,213 @@ def jupyter_config_path():
             paths.append(p)
     paths.extend(SYSTEM_CONFIG_PATH)
     return paths
+
+
+def exists(path):
+    """Replacement for `os.path.exists` which works for host mapped volumes
+    on Windows containers
+    """
+    try:
+        os.lstat(path)
+    except OSError:
+        return False
+    return True
+
+
+def is_file_hidden_win(abs_path, stat_res=None):
+    """Is a file hidden?
+
+    This only checks the file itself; it should be called in combination with
+    checking the directory containing the file.
+
+    Use is_hidden() instead to check the file and its parent directories.
+
+    Parameters
+    ----------
+    abs_path : unicode
+        The absolute path to check.
+    stat_res : os.stat_result, optional
+        Ignored on Windows, exists for compatibility with POSIX version of the
+        function.
+    """
+    if os.path.basename(abs_path).startswith('.'):
+        return True
+
+    win32_FILE_ATTRIBUTE_HIDDEN = 0x02
+    import ctypes
+    try:
+        attrs = ctypes.windll.kernel32.GetFileAttributesW(
+            py3compat.cast_unicode(abs_path)
+        )
+    except AttributeError:
+        pass
+    else:
+        if attrs > 0 and attrs & win32_FILE_ATTRIBUTE_HIDDEN:
+            return True
+
+    return False
+
+
+def is_file_hidden_posix(abs_path, stat_res=None):
+    """Is a file hidden?
+
+    This only checks the file itself; it should be called in combination with
+    checking the directory containing the file.
+
+    Use is_hidden() instead to check the file and its parent directories.
+
+    Parameters
+    ----------
+    abs_path : unicode
+        The absolute path to check.
+    stat_res : os.stat_result, optional
+        The result of calling stat() on abs_path. If not passed, this function
+        will call stat() internally.
+    """
+    if os.path.basename(abs_path).startswith('.'):
+        return True
+
+    if stat_res is None or stat.S_ISLNK(stat_res.st_mode):
+        try:
+            stat_res = os.stat(abs_path)
+        except OSError as e:
+            if e.errno == errno.ENOENT:
+                return False
+            raise
+
+    # check that dirs can be listed
+    if stat.S_ISDIR(stat_res.st_mode):
+        # use x-access, not actual listing, in case of slow/large listings
+        if not os.access(abs_path, os.X_OK | os.R_OK):
+            return True
+
+    # check UF_HIDDEN
+    if getattr(stat_res, 'st_flags', 0) & UF_HIDDEN:
+        return True
+
+    return False
+
+
+if sys.platform == 'win32':
+    is_file_hidden = is_file_hidden_win
+else:
+    is_file_hidden = is_file_hidden_posix
+
+
+def is_hidden(abs_path, abs_root=''):
+    """Is a file hidden or contained in a hidden directory?
+
+    This will start with the rightmost path element and work backwards to the
+    given root to see if a path is hidden or in a hidden directory. Hidden is
+    determined by either name starting with '.' or the UF_HIDDEN flag as
+    reported by stat.
+
+    If abs_path is the same directory as abs_root, it will be visible even if
+    that is a hidden folder. This only checks the visibility of files
+    and directories *within* abs_root.
+
+    Parameters
+    ----------
+    abs_path : unicode
+        The absolute path to check for hidden directories.
+    abs_root : unicode
+        The absolute path of the root directory in which hidden directories
+        should be checked for.
+    """
+    if os.path.normpath(abs_path) == os.path.normpath(abs_root):
+        return False
+
+    if is_file_hidden(abs_path):
+        return True
+
+    if not abs_root:
+        abs_root = abs_path.split(os.sep, 1)[0] + os.sep
+    inside_root = abs_path[len(abs_root):]
+    if any(part.startswith('.') for part in inside_root.split(os.sep)):
+        return True
+
+    # check UF_HIDDEN on any location up to root.
+    # is_file_hidden() already checked the file, so start from its parent dir
+    path = os.path.dirname(abs_path)
+    while path and path.startswith(abs_root) and path != abs_root:
+        if not exists(path):
+            path = os.path.dirname(path)
+            continue
+        try:
+            # may fail on Windows junctions
+            st = os.lstat(path)
+        except OSError:
+            return True
+        if getattr(st, 'st_flags', 0) & UF_HIDDEN:
+            return True
+        path = os.path.dirname(path)
+
+    return False
+
+
+def win32_restrict_file_to_user(fname):
+    """Secure a windows file to read-only access for the user.
+    Follows guidance from win32 library creator:
+    http://timgolden.me.uk/python/win32_how_do_i/add-security-to-a-file.html
+
+    This method should be executed against an already generated file which
+    has no secrets written to it yet.
+
+    Parameters
+    ----------
+
+    fname : unicode
+        The path to the file to secure
+    """
+    import win32api
+    import win32security
+    import ntsecuritycon as con
+
+    # everyone, _domain, _type = win32security.LookupAccountName("", "Everyone")
+    admins, _domain, _type = win32security.LookupAccountName("", "Administrators")
+    user, _domain, _type = win32security.LookupAccountName("", win32api.GetUserName())
+
+    sd = win32security.GetFileSecurity(fname, win32security.DACL_SECURITY_INFORMATION)
+
+    dacl = win32security.ACL()
+    # dacl.AddAccessAllowedAce(win32security.ACL_REVISION, con.FILE_ALL_ACCESS, everyone)
+    dacl.AddAccessAllowedAce(win32security.ACL_REVISION, con.FILE_GENERIC_READ | con.FILE_GENERIC_WRITE, user)
+    dacl.AddAccessAllowedAce(win32security.ACL_REVISION, con.FILE_ALL_ACCESS, admins)
+
+    sd.SetSecurityDescriptorDacl(1, dacl, 0)
+    win32security.SetFileSecurity(fname, win32security.DACL_SECURITY_INFORMATION, sd)
+
+@contextmanager
+def secure_write(fname, binary=False):
+    """Opens a file in the most restricted pattern available for
+    writing content. This limits the file mode to `600` and yields
+    the resulting opened filed handle.
+
+    Parameters
+    ----------
+
+    fname : unicode
+        The path to the file to write
+    """
+    mode = 'wb' if binary else 'w'
+    open_flag = os.O_CREAT | os.O_WRONLY | os.O_TRUNC
+    try:
+        os.remove(fname)
+    except (IOError, OSError):
+        # Skip any issues with the file not existing
+        pass
+
+    if os.name == 'nt':
+        # Python on windows does not respect the group and public bits for chmod, so we need
+        # to take additional steps to secure the contents.
+        # Touch file pre-emptively to avoid editing permissions in open files in Windows
+        fd = os.open(fname, os.O_CREAT | os.O_WRONLY | os.O_TRUNC, 0o600)
+        os.close(fd)
+        open_flag = os.O_WRONLY | os.O_TRUNC
+        win32_restrict_file_to_user(fname)
+
+    with os.fdopen(os.open(fname, open_flag, 0o600), mode) as f:
+        if os.name != 'nt':
+            # Enforce that the file got the requested permissions before writing
+            assert '0600' == oct(stat.S_IMODE(os.stat(fname).st_mode)).replace('0o', '0')
+        yield f

--- a/jupyter_core/paths.py
+++ b/jupyter_core/paths.py
@@ -404,5 +404,8 @@ def secure_write(fname, binary=False):
     with os.fdopen(os.open(fname, open_flag, 0o600), mode) as f:
         if os.name != 'nt':
             # Enforce that the file got the requested permissions before writing
-            assert '0600' == oct(stat.S_IMODE(os.stat(fname).st_mode)).replace('0o', '0')
+            if '0600' != oct(stat.S_IMODE(os.stat(fname).st_mode)).replace('0o', '0'):
+                raise RuntimeError("Permissions assignment failed for secure file: '{file}'."
+                    "Got '{permissions}' instead of '600'"
+                    .format(file=fname, permissions=os.stat(fname).st_mode))
         yield f

--- a/jupyter_core/paths.py
+++ b/jupyter_core/paths.py
@@ -359,7 +359,7 @@ def win32_restrict_file_to_user(fname):
     import ntsecuritycon as con
 
     # everyone, _domain, _type = win32security.LookupAccountName("", "Everyone")
-    admins, _domain, _type = win32security.LookupAccountName("", "Administrators")
+    admins = win32security.CreateWellKnownSid(win32security.WinBuiltinAdministratorsSid)
     user, _domain, _type = win32security.LookupAccountName("", win32api.GetUserName())
 
     sd = win32security.GetFileSecurity(fname, win32security.DACL_SECURITY_INFORMATION)

--- a/jupyter_core/tests/test_paths.py
+++ b/jupyter_core/tests/test_paths.py
@@ -4,6 +4,10 @@
 # Distributed under the terms of the Modified BSD License.
 
 import os
+import re
+import stat
+import shutil
+import tempfile
 
 try:
     from unittest.mock import patch
@@ -14,7 +18,11 @@ from jupyter_core import paths
 from jupyter_core.paths import (
     jupyter_config_dir, jupyter_data_dir, jupyter_runtime_dir,
     jupyter_path, ENV_JUPYTER_PATH,
+    secure_write, is_hidden, is_file_hidden
 )
+from ipython_genutils.tempdir import TemporaryDirectory
+from ipython_genutils.py3compat import cast_unicode
+from ipython_genutils.testing.decorators import skip_if_not_win32, skip_win32
 from .mocking import darwin, windows, linux
 
 pjoin = os.path.join
@@ -55,7 +63,7 @@ def test_config_dir_darwin():
     with darwin, no_config_env:
         config = jupyter_config_dir()
     assert config == home_jupyter
-    
+
     with darwin, config_env:
         config = jupyter_config_dir()
     assert config == jupyter_config_env
@@ -65,7 +73,7 @@ def test_config_dir_windows():
     with windows, no_config_env:
         config = jupyter_config_dir()
     assert config == home_jupyter
-    
+
     with windows, config_env:
         config = jupyter_config_dir()
     assert config == jupyter_config_env
@@ -75,7 +83,7 @@ def test_config_dir_linux():
     with windows, no_config_env:
         config = jupyter_config_dir()
     assert config == home_jupyter
-    
+
     with windows, config_env:
         config = jupyter_config_dir()
     assert config == jupyter_config_env
@@ -92,7 +100,7 @@ def test_data_dir_darwin():
     with darwin:
         data = jupyter_data_dir()
     assert data == realpath('~/Library/Jupyter')
-    
+
     with darwin, xdg:
         # darwin should ignore xdg
         data = jupyter_data_dir()
@@ -103,7 +111,7 @@ def test_data_dir_windows():
     with windows, appdata:
         data = jupyter_data_dir()
     assert data == pjoin('appdata', 'jupyter')
-    
+
     with windows, appdata, xdg:
         # windows should ignore xdg
         data = jupyter_data_dir()
@@ -114,7 +122,7 @@ def test_data_dir_linux():
     with linux, no_xdg:
         data = jupyter_data_dir()
     assert data == realpath('~/.local/share/jupyter')
-    
+
     with linux, xdg:
         data = jupyter_data_dir()
     assert data == pjoin(xdg_env['XDG_DATA_HOME'], 'jupyter')
@@ -131,7 +139,7 @@ def test_runtime_dir_darwin():
     with darwin:
         runtime = jupyter_runtime_dir()
     assert runtime == realpath('~/Library/Jupyter/runtime')
-    
+
     with darwin, xdg:
         # darwin should ignore xdg
         runtime = jupyter_runtime_dir()
@@ -142,7 +150,7 @@ def test_runtime_dir_windows():
     with windows, appdata:
         runtime = jupyter_runtime_dir()
     assert runtime == pjoin('appdata', 'jupyter', 'runtime')
-    
+
     with windows, appdata, xdg:
         # windows should ignore xdg
         runtime = jupyter_runtime_dir()
@@ -153,7 +161,7 @@ def test_runtime_dir_linux():
     with linux, no_xdg:
         runtime = jupyter_runtime_dir()
     assert runtime == realpath('~/.local/share/jupyter/runtime')
-    
+
     with linux, xdg:
         runtime = jupyter_runtime_dir()
     assert runtime == pjoin(xdg_env['XDG_DATA_HOME'], 'jupyter', 'runtime')
@@ -172,7 +180,7 @@ def test_jupyter_path_env():
         pjoin('foo', 'bar'),
         pjoin('bar', 'baz', ''), # trailing /
     ])
-    
+
     with patch.dict('os.environ', {'JUPYTER_PATH': path_env}):
         path = jupyter_path()
     assert path[:2] == [pjoin('foo', 'bar'), pjoin('bar', 'baz')]
@@ -189,3 +197,110 @@ def test_jupyter_path_subdir():
     for p in path:
         assert p.endswith(pjoin('', 'sub1', 'sub2'))
 
+
+def test_is_hidden():
+    with TemporaryDirectory() as root:
+        subdir1 = os.path.join(root, 'subdir')
+        os.makedirs(subdir1)
+        assert not is_hidden(subdir1, root)
+        assert not is_file_hidden(subdir1)
+
+        subdir2 = os.path.join(root, '.subdir2')
+        os.makedirs(subdir2)
+        assert is_hidden(subdir2, root)
+        assert is_file_hidden(subdir2)
+        # root dir is always visible
+        assert not is_hidden(subdir2, subdir2)
+
+        subdir34 = os.path.join(root, 'subdir3', '.subdir4')
+        os.makedirs(subdir34)
+        assert is_hidden(subdir34, root)
+        assert is_hidden(subdir34)
+
+        subdir56 = os.path.join(root, '.subdir5', 'subdir6')
+        os.makedirs(subdir56)
+        assert is_hidden(subdir56, root)
+        assert is_hidden(subdir56)
+        assert not is_file_hidden(subdir56)
+        assert not is_file_hidden(subdir56, os.stat(subdir56))
+
+
+@skip_if_not_win32
+def test_is_hidden_win32():
+    import ctypes
+    with TemporaryDirectory() as root:
+        root = cast_unicode(root)
+        subdir1 = os.path.join(root, u'subdir')
+        os.makedirs(subdir1)
+        assert not is_hidden(subdir1, root)
+        r = ctypes.windll.kernel32.SetFileAttributesW(subdir1, 0x02)
+        print(r) # Helps debugging
+        assert is_hidden(subdir1, root)
+        assert is_file_hidden(subdir1)
+
+
+@skip_if_not_win32
+def test_secure_write_win32():
+    def fetch_win32_permissions(filename):
+        '''Extracts file permissions on windows using icacls'''
+        role_permissions = {}
+        for index, line in enumerate(os.popen("icacls %s" % filename).read().splitlines()):
+            if index == 0:
+                line = line.split(filename)[-1].strip().lower()
+            match = re.match(r'\s*([^:]+):\(([^\)]*)\)', line)
+            if match:
+                usergroup, permissions = match.groups()
+                usergroup = usergroup.lower().split('\\')[-1]
+                permissions = set(p.lower() for p in permissions.split(','))
+                role_permissions[usergroup] = permissions
+            elif not line.strip():
+                break
+        return role_permissions
+
+    def check_user_only_permissions(fname):
+        # Windows has it's own permissions ACL patterns
+        import win32api
+        username = win32api.GetUserName().lower()
+        permissions = fetch_win32_permissions(fname)
+        print(permissions) # for easier debugging
+        assert username in permissions
+        assert permissions[username] == set(['r', 'w'])
+        assert 'administrators' in permissions
+        assert permissions['administrators'] == set(['f'])
+        assert 'everyone' not in permissions
+        assert len(permissions) == 2
+
+    directory = tempfile.mkdtemp()
+    fname = os.path.join(directory, 'check_perms')
+    try:
+        with secure_write(fname) as f:
+            f.write('test 1')
+        check_user_only_permissions(fname)
+        with open(fname, 'r') as f:
+            assert f.read() == 'test 1'
+    finally:
+        shutil.rmtree(directory)
+
+
+@skip_win32
+def test_secure_write_unix():
+    directory = tempfile.mkdtemp()
+    fname = os.path.join(directory, 'check_perms')
+    try:
+        with secure_write(fname) as f:
+            f.write('test 1')
+        mode = os.stat(fname).st_mode
+        assert '0600' == oct(stat.S_IMODE(mode)).replace('0o', '0')
+        with open(fname, 'r') as f:
+            assert f.read() == 'test 1'
+
+        # Try changing file permissions ahead of time
+        os.chmod(fname, 0o755)
+        with secure_write(fname) as f:
+            f.write('test 2')
+        mode = os.stat(fname).st_mode
+        assert '0600' == oct(stat.S_IMODE(mode)).replace('0o', '0')
+        with open(fname, 'r') as f:
+            assert f.read() == 'test 2'
+    finally:
+        shutil.rmtree(directory)

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,7 @@ include_package_data = True
 python_requires = >=2.7, !=3.0, !=3.1, !=3.2
 install_requires =
     traitlets
+    pywin32>=1.0 ; sys_platform == 'win32'
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
Moved shared code from https://github.com/jupyter/jupyter_server/pull/77 and https://github.com/jupyter/jupyter_client/pull/469 as well as some other path related utils in jupyrer_server that seemed useful in a more generic scope. No code changes made on the functions  other than converting the tests from nose.assert pattern to pytest assert pattern.

Tested on windows & ubuntu independently