### PR TITLE
Use GetUserNameEx to get SID of current user to secure win32 files

### DIFF
--- a/jupyter_core/paths.py
+++ b/jupyter_core/paths.py
@@ -362,7 +362,7 @@ def win32_restrict_file_to_user(fname):
 
     # everyone, _domain, _type = win32security.LookupAccountName("", "Everyone")
     admins = win32security.CreateWellKnownSid(win32security.WinBuiltinAdministratorsSid)
-    user, _domain, _type = win32security.LookupAccountName("", win32api.GetUserName())
+    user, _domain, _type = win32security.LookupAccountName("", win32api.GetUserNameEx(win32api.NameSamCompatible))
 
     sd = win32security.GetFileSecurity(fname, win32security.DACL_SECURITY_INFORMATION)
 


### PR DESCRIPTION
Found that the SID obtained when using GetUserName was causing permission
issues because it wasn't the actual SID for the current user.  By changing
the call to use `GetUserNameEx` with a parameter of `NameSamCompatible`,
the SID that was returned did indeed correspond to the current user.  In
addition, analysis of the file using Windows explorer also showed the SID
being resolved to the current user's Windows ID, rather than a raw SID (as
before).

Co-authored-by: snapo <6347922+snapo@users.noreply.github.com>