### PR TITLE
Tolerate execute bit on owner when writing file

### DIFF
--- a/jupyter_core/tests/test_paths.py
+++ b/jupyter_core/tests/test_paths.py
@@ -290,7 +290,7 @@ def test_secure_write_unix():
         with secure_write(fname) as f:
             f.write('test 1')
         mode = os.stat(fname).st_mode
-        assert '0600' == oct(stat.S_IMODE(mode)).replace('0o', '0')
+        assert 0o0600 == (stat.S_IMODE(mode) & 0o7677)  # tolerate owner-execute bit
         with open(fname, 'r') as f:
             assert f.read() == 'test 1'
 
@@ -299,7 +299,7 @@ def test_secure_write_unix():
         with secure_write(fname) as f:
             f.write('test 2')
         mode = os.stat(fname).st_mode
-        assert '0600' == oct(stat.S_IMODE(mode)).replace('0o', '0')
+        assert 0o0600 == (stat.S_IMODE(mode) & 0o7677)  # tolerate owner-execute bit
         with open(fname, 'r') as f:
             assert f.read() == 'test 2'
     finally:


### PR DESCRIPTION
Some filesystems (CIFS) auto-enable execute bits on files.  As
a result, we should tolerate execute on owner (but only owner).

Special thanks to @hroncok for providing the missing tidbits to this issue! (Pun intended)

Closes: #172