### PR TITLE
Travis CI: Add Python 3.7 and 3.8 and remove the EOL 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 # http://travis-ci.org/#!/jupyter/jupyter_core
 language: python
-sudo: false
 python:
   - nightly
+  - "3.8"
+  - "3.7"
   - "3.6"
   - "3.5"
-  - "3.4"
   - "2.7"
 before_install:
   - pip install --upgrade pip


### PR DESCRIPTION
Travis runtimes are interesting.  Why does `pip install -r requirements.txt` take several times longer on Py38 and nightly than all other Python versions? https://travis-ci.org/jupyter/jupyter_core/builds/603413767?utm_source=github_status&utm_medium=notification