### PR TITLE
Ignore sticky bit when validating permissions.

### DIFF
--- a/jupyter_core/paths.py
+++ b/jupyter_core/paths.py
@@ -388,7 +388,7 @@ def get_file_mode(fname):
     # Some filesystems (e.g., CIFS) auto-enable the execute bit on files.  As a result, we
     # should tolerate the execute bit on the file's owner when validating permissions - thus
     # the missing one's bit on the third octet.
-    return stat.S_IMODE(os.stat(fname).st_mode) & 0o7677  # Use 4 octets since S_IMODE does the same
+    return stat.S_IMODE(os.stat(fname).st_mode) & 0o6677  # Use 4 octets since S_IMODE does the same
 
 
 @contextmanager

--- a/jupyter_core/paths.py
+++ b/jupyter_core/paths.py
@@ -386,8 +386,9 @@ def get_file_mode(fname):
 
     """
     # Some filesystems (e.g., CIFS) auto-enable the execute bit on files.  As a result, we
-    # should tolerate the execute bit on the file's owner when validating permissions - thus
-    # the missing one's bit on the third octet.
+    # should tolerate the execute bit on the file's owner when validating permissions - thus 
+    # the missing least significant bit on the third octet. In addition, we also tolerate 
+    # the sticky bit being set, so the lsb from the fourth octet is also removed.
     return stat.S_IMODE(os.stat(fname).st_mode) & 0o6677  # Use 4 octets since S_IMODE does the same
 
 
@@ -429,6 +430,6 @@ def secure_write(fname, binary=False):
             file_mode = get_file_mode(fname)
             if 0o0600 != file_mode:
                 raise RuntimeError("Permissions assignment failed for secure file: '{file}'."
-                    "Got '{permissions}' instead of '0o0600'"
+                    " Got '{permissions}' instead of '0o0600'."
                     .format(file=fname, permissions=oct(file_mode)))
         yield f

--- a/jupyter_core/paths.py
+++ b/jupyter_core/paths.py
@@ -387,9 +387,9 @@ def get_file_mode(fname):
     """
     # Some filesystems (e.g., CIFS) auto-enable the execute bit on files.  As a result, we
     # should tolerate the execute bit on the file's owner when validating permissions - thus 
-    # the missing least significant bit on the third octet. In addition, we also tolerate 
-    # the sticky bit being set, so the lsb from the fourth octet is also removed.
-    return stat.S_IMODE(os.stat(fname).st_mode) & 0o6677  # Use 4 octets since S_IMODE does the same
+    # the missing least significant bit on the third octal digit. In addition, we also tolerate 
+    # the sticky bit being set, so the lsb from the fourth octal digit is also removed.
+    return stat.S_IMODE(os.stat(fname).st_mode) & 0o6677  # Use 4 octal digits since S_IMODE does the same
 
 
 @contextmanager


### PR DESCRIPTION
On [Nextjournal](https://nextjournal.com/) we use a standard connection file which is mounted to docker containers in order to support Jupyter runtimes.  Since the addition of `secure_write` we can get an initial startup just fine by setting permissions on the file.  However, with some Jupyter kernels it seems the Sticky Bit gets set, and this persists on the mounted file through restarts and resets, causing `secure_write` to fail:
```
RuntimeError: Permissions assignment failed for secure file: '/runtimes/jupyter/kernel_connection.json'.Got '0o1600' instead of '0o0600'
```
I don't think the Sticky Bit is a security risk(?), so I see no reason it shouldn't be ignored.  [Tested the fork](https://nextjournal.com/a/LnBMKtooyHaE7id2qrbrG?token=RjwFVRya7ycP1uQ3E9xCyw), and this change does clear up our problem.