### PR TITLE
Add readthedocs YAML config

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,0 +1,3 @@
+python:
+  pip_install: true
+requirements_file: docs/requirements.txt


### PR DESCRIPTION
Doing `setup.py install` is blocked to work around setuptools problems, and doing `pip install .` instead can seemingly only be configured through the YAML file.