### PR TITLE
Add ability to allow insecure writes

### DIFF
--- a/jupyter_core/application.py
+++ b/jupyter_core/application.py
@@ -36,7 +36,8 @@ from ipython_genutils import py3compat
 
 from .paths import (
     jupyter_config_dir, jupyter_data_dir, jupyter_runtime_dir,
-    jupyter_path, jupyter_config_path,
+    jupyter_path, jupyter_config_path, allow_insecure_writes,
+    issue_insecure_write_warning
 )
 
 # aliases and flags
@@ -245,8 +246,9 @@ class JupyterApp(Application):
         self.load_config_file()
         # enforce cl-opts override configfile opts:
         self.update_config(cl_config)
-    
-    
+        if allow_insecure_writes:
+            issue_insecure_write_warning()
+
     def start(self):
         """Start the whole thing"""
         if self.subcommand:

--- a/jupyter_core/paths.py
+++ b/jupyter_core/paths.py
@@ -17,6 +17,7 @@ import tempfile
 from ipython_genutils import py3compat
 
 from contextlib import contextmanager
+from distutils.util import strtobool
 from ipython_genutils import py3compat
 
 pjoin = os.path.join
@@ -392,6 +393,9 @@ def get_file_mode(fname):
     return stat.S_IMODE(os.stat(fname).st_mode) & 0o6677  # Use 4 octal digits since S_IMODE does the same
 
 
+allow_insecure_writes = strtobool(os.getenv('JUPYTER_ALLOW_INSECURE_WRITES', 'false'))
+
+
 @contextmanager
 def secure_write(fname, binary=False):
     """Opens a file in the most restricted pattern available for
@@ -428,7 +432,7 @@ def secure_write(fname, binary=False):
         if os.name != 'nt':
             # Enforce that the file got the requested permissions before writing
             file_mode = get_file_mode(fname)
-            if 0o0600 != file_mode:
+            if 0o0600 != file_mode and not allow_insecure_writes:
                 raise RuntimeError("Permissions assignment failed for secure file: '{file}'."
                     " Got '{permissions}' instead of '0o0600'."
                     .format(file=fname, permissions=oct(file_mode)))


### PR DESCRIPTION
Per a [previous discussion](https://github.com/jupyter/jupyter_client/issues/507), this change enables users to bypass the file permissions enforcement within `secure_write()`.  This has become an issue when secure files reside on filesystems that automatically promote file permissions to o777 and prevents changes to those settings.  In such cases, users can prevent enforcement by setting environment variable `JUPYTER_ALLOW_INSECURE_WRITES` to true (default = false).

I debated on the polarity of the env variable name.  I liked `JUPYTER_ENFORCE_SECURE_WRITES` but felt having a variable that defaults to True was a bit odd.  Also, I felt that users setting something to skip security by having to set it to True was a more explicit action.

In looking at testing this change, I couldn't find a way to get a file created such that it would exhibit the behavior of one of these filesystems.  Since the change is trivial, I figured this could be a visual inspection kind of thing.
