### PR TITLE
Add opt-in support for XDG_CONFIG_HOME, XDG_DATA_HOME

### DIFF
--- a/jupyter_core/paths.py
+++ b/jupyter_core/paths.py
@@ -90,21 +90,26 @@ def jupyter_data_dir():
         return env['JUPYTER_DATA_DIR']
 
     home = get_home_dir()
+    xdg = env.get('XDG_DATA_HOME')
 
     if sys.platform == 'darwin':
-        return os.path.join(home, 'Library', 'Jupyter')
-    elif os.name == 'nt':
+        default = pjoin(home, 'Library', 'Jupyter')
+
+        # Use XDG_DATA_HOME if and only if the default doesn't exist.
+        if not exists(default) and xdg:
+            return pjoin(xdg, 'jupyter')
+        return default
+
+    if os.name == 'nt':
         appdata = os.environ.get('APPDATA', None)
         if appdata:
             return pjoin(appdata, 'jupyter')
-        else:
-            return pjoin(jupyter_config_dir(), 'data')
-    else:
-        # Linux, non-OS X Unix, AIX, etc.
-        xdg = env.get("XDG_DATA_HOME", None)
-        if not xdg:
-            xdg = pjoin(home, '.local', 'share')
-        return pjoin(xdg, 'jupyter')
+        return pjoin(jupyter_config_dir(), 'data')
+
+    # Linux, non-OS X Unix, AIX, etc.
+    if not xdg:
+        xdg = pjoin(home, '.local', 'share')
+    return pjoin(xdg, 'jupyter')
 
 
 def jupyter_runtime_dir():

--- a/jupyter_core/paths.py
+++ b/jupyter_core/paths.py
@@ -53,7 +53,8 @@ def _mkdtemp_once(name):
 def jupyter_config_dir():
     """Get the Jupyter config directory for this platform and user.
 
-    Returns JUPYTER_CONFIG_DIR if defined, else ~/.jupyter
+    Returns the first valid path from JUPYTER_CONFIG_DIR if defined, ~/.jupyter
+    if it exists, and XDG_CONFIG_HOME if defined, falling back to ~/.jupyter.
     """
 
     env = os.environ
@@ -65,8 +66,16 @@ def jupyter_config_dir():
     if env.get('JUPYTER_CONFIG_DIR'):
         return env['JUPYTER_CONFIG_DIR']
 
-    return pjoin(home_dir, '.jupyter')
+    default = pjoin(home_dir, '.jupyter')
+    xdg = env.get('XDG_CONFIG_HOME')
 
+    # Check XDG_CONFIG_HOME if and only if .jupyter doesn't exist.
+    # This ensures that existing installs keep working until explicit opt-in.
+    if not exists(default) and xdg:
+        return pjoin(xdg, 'jupyter')
+
+    return default
+    
 
 def jupyter_data_dir():
     """Get the config directory for Jupyter data files.


### PR DESCRIPTION
- Allow opt-in use of `XDG_CONFIG_HOME` on all platforms
- Allow opt-in use of `XDG_DATA_HOME` on Darwin

Related: #185 