### PR TITLE
Add conda env export info

### DIFF
--- a/jupyter_core/troubleshoot.py
+++ b/jupyter_core/troubleshoot.py
@@ -47,6 +47,7 @@ def get_data():
         env['where'] = None
     env['pip'] = subs([sys.executable, '-m', 'pip', 'list'])
     env['conda'] = subs(['conda', 'list'])
+    env['conda-env'] = subs(['conda', 'env', 'export'])
     return env
 
 
@@ -99,6 +100,10 @@ def main():
         for package in environment_data['conda'].split('\n'):
             print('\t' + package)
 
+    if environment_data['conda-env']:
+        print('\n' + 'conda env:')
+        for package in environment_data['conda-env'].split('\n'):
+            print('\t' + package)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
This makes it easier to re-create the exact conditions as the user reporting an issue by running `conda env create --file environment.yml`.  Example output:

<details>
<pre>
conda env:
	name: /tmp/conda_envs/95dbb6925f9d9cc84dbb167d
	channels:
	  - conda-forge
	  - defaults
	dependencies:
	  - appnope=0.1.0=py36h9f0ad1d_1001
	  - attrs=19.3.0=py_0
	  - backcall=0.1.0=py_0
	  - bleach=3.1.4=pyh9f0ad1d_0
	  - ca-certificates=2020.4.5.1=hecc5488_0
	  - certifi=2020.4.5.1=py36h9f0ad1d_0
	  - decorator=4.4.2=py_0
	  - defusedxml=0.6.0=py_0
	  - entrypoints=0.3=py36h9f0ad1d_1001
	  - importlib-metadata=1.6.0=py36h9f0ad1d_0
	  - importlib_metadata=1.6.0=0
	  - ipykernel=5.2.1=py36h95af2a2_0
	  - ipython=7.13.0=py36h9f0ad1d_2
	  - ipython_genutils=0.2.0=py_1
	  - jedi=0.17.0=py36h9f0ad1d_0
	  - jinja2=2.11.2=pyh9f0ad1d_0
	  - jsonschema=3.2.0=py36h9f0ad1d_1
	  - jupyter_client=6.1.3=py_0
	  - jupyter_core=4.6.3=py36h9f0ad1d_1
	  - libcxx=10.0.0=h1af66ff_2
	  - libffi=3.2.1=h4a8c4bd_1007
	  - libsodium=1.0.17=h01d97ff_0
	  - markupsafe=1.1.1=py36h37b9a7d_1
	  - mistune=0.8.4=py36h37b9a7d_1001
	  - nbconvert=5.6.1=py36h9f0ad1d_1
	  - nbformat=5.0.6=py_0
	  - ncurses=6.1=h0a44026_1002
	  - notebook=6.0.3=py36_0
	  - openssl=1.1.1g=h0b31af3_0
	  - pandoc=2.9.2.1=0
	  - pandocfilters=1.4.2=py_1
	  - parso=0.7.0=pyh9f0ad1d_0
	  - pexpect=4.8.0=py36h9f0ad1d_1
	  - pickleshare=0.7.5=py36h9f0ad1d_1001
	  - pip=20.0.2=py_2
	  - prometheus_client=0.7.1=py_0
	  - prompt-toolkit=3.0.5=py_0
	  - ptyprocess=0.6.0=py_1001
	  - pygments=2.6.1=py_0
	  - pyrsistent=0.16.0=py36h37b9a7d_0
	  - python=3.6.10=h4334963_1011_cpython
	  - python-dateutil=2.8.1=py_0
	  - python_abi=3.6=1_cp36m
	  - pyzmq=19.0.0=py36h820b253_1
	  - readline=8.0=hcfe32e1_0
	  - send2trash=1.5.0=py_0
	  - setuptools=46.1.3=py36h9f0ad1d_0
	  - six=1.14.0=py_1
	  - sqlite=3.30.1=h93121df_0
	  - terminado=0.8.3=py36h9f0ad1d_1
	  - testpath=0.4.4=py_0
	  - tk=8.6.10=hbbe82c9_0
	  - tornado=6.0.4=py36h37b9a7d_1
	  - traitlets=4.3.3=py36h9f0ad1d_1
	  - wcwidth=0.1.9=pyh9f0ad1d_0
	  - webencodings=0.5.1=py_1
	  - wheel=0.34.2=py_1
	  - xz=5.2.5=h0b31af3_0
	  - zeromq=4.3.2=h6de7cb9_2
	  - zipp=3.1.0=py_0
	  - zlib=1.2.11=h0b31af3_1006
	prefix: /tmp/conda_envs/95dbb6925f9d9cc84dbb167d
</pre>
</details>