### PR TITLE
Replace strtobool to avoid distutils import

### DIFF
--- a/jupyter_core/paths.py
+++ b/jupyter_core/paths.py
@@ -18,7 +18,6 @@ import warnings
 from ipython_genutils import py3compat
 
 from contextlib import contextmanager
-from distutils.util import strtobool
 from ipython_genutils import py3compat
 
 pjoin = os.path.join
@@ -394,7 +393,7 @@ def get_file_mode(fname):
     return stat.S_IMODE(os.stat(fname).st_mode) & 0o6677  # Use 4 octal digits since S_IMODE does the same
 
 
-allow_insecure_writes = strtobool(os.getenv('JUPYTER_ALLOW_INSECURE_WRITES', 'false'))
+allow_insecure_writes = os.getenv('JUPYTER_ALLOW_INSECURE_WRITES', 'false').lower() in ('true', '1')
 
 
 @contextmanager


### PR DESCRIPTION
This removes the `strtobool` import from `distutils.util`, used for evaluating the value of the `JUPYTER_ALLOW_INSECURE_WRITES` environment variable, and replaces it by a straightforward expression. See comments in #193 for the justification.

Strictly speaking, this breaks backwards compatibility because the proposed implementation:
1. only accepts "true" (ignoring case) and "1" as `True` values, whereas the previous implementation also accepted "y", "yes", "t", and "on".
2. stores a `True`/`False` boolean in the `allow_insecure_writes` variable, whereas the previous implementation stored integer numbers `1`/`0`.

To me (as an outsider of the jupyter project), this does not seem to be a problem since these implementation details were only available from the source code, and internally the variable is only used as a boolean value. As far as I can tell, the only public documentation of the feature is [here](https://discourse.jupyter.org/t/jupyter-core-4-6-2-release-with-insure-mode-option/3300) and only mentions "true" and "1". All other mentions I found (e.g. on [stackoverflow](https://stackoverflow.com/questions/59934047/jupyter-access-denied-error-when-starting-kernel-in-spyder-jupyter-notebook)) seem to use "1" as a value.

I did not add any tests, since I think you'd need to restructure the code a bit for proper testing (the `allow_insecure_writes` variable is currently set at module import time).