### PR TITLE
Add an environment variable flag to switch the user and environment path order

### DIFF
--- a/jupyter_core/command.py
+++ b/jupyter_core/command.py
@@ -231,13 +231,13 @@ def main():
                 if args.debug:
                     env = os.environ
 
-                    if paths.JUPYTER_PREFER_ENV_PATH:
+                    if paths.envset('JUPYTER_PREFER_ENV_PATH'):
                         print("JUPYTER_PREFER_ENV_PATH is set, making the environment-level path preferred over the user-level path for data and config")
                     else:
                         print("JUPYTER_PREFER_ENV_PATH is not set, making the user-level path preferred over the environment-level path for data and config")
 
                     # config path list
-                    if env.get('JUPYTER_NO_CONFIG'):
+                    if paths.envset('JUPYTER_NO_CONFIG'):
                         print("JUPYTER_NO_CONFIG is set, making the config path list only a single temporary directory")
                     else:
                         print("JUPYTER_NO_CONFIG is not set, so we use the full path list for config")

--- a/jupyter_core/command.py
+++ b/jupyter_core/command.py
@@ -53,6 +53,8 @@ def jupyter_parser():
         help="show all Jupyter paths. Add --json for machine-readable format.")
     parser.add_argument('--json', action='store_true',
         help="output paths as machine-readable json")
+    parser.add_argument('--debug', action='store_true',
+        help="output debug information about paths")
 
     return parser
 
@@ -205,6 +207,10 @@ def main():
             return
         if args.json and not args.paths:
             sys.exit("--json is only used with --paths")
+        if args.debug and not args.paths:
+            sys.exit("--debug is only used with --paths")
+        if args.debug and args.json:
+            sys.exit("--debug cannot be used with --json")
         if args.config_dir:
             print(paths.jupyter_config_dir())
             return
@@ -222,6 +228,9 @@ def main():
             if args.json:
                 print(json.dumps(data))
             else:
+                if args.debug:
+                    if paths.JUPYTER_PREFER_ENV_PATH:
+                        print("JUPYTER_PREFER_ENV_PATH is set, making the environment-level path preferred over the user-level path")
                 for name in sorted(data):
                     path = data[name]
                     print('%s:' % name)

--- a/jupyter_core/command.py
+++ b/jupyter_core/command.py
@@ -229,8 +229,48 @@ def main():
                 print(json.dumps(data))
             else:
                 if args.debug:
+                    env = os.environ
+
                     if paths.JUPYTER_PREFER_ENV_PATH:
-                        print("JUPYTER_PREFER_ENV_PATH is set, making the environment-level path preferred over the user-level path")
+                        print("JUPYTER_PREFER_ENV_PATH is set, making the environment-level path preferred over the user-level path for data and config")
+                    else:
+                        print("JUPYTER_PREFER_ENV_PATH is not set, making the user-level path preferred over the environment-level path for data and config")
+
+                    # config path list
+                    if env.get('JUPYTER_NO_CONFIG'):
+                        print("JUPYTER_NO_CONFIG is set, making the config path list only a single temporary directory")
+                    else:
+                        print("JUPYTER_NO_CONFIG is not set, so we use the full path list for config")
+
+                    if env.get('JUPYTER_CONFIG_PATH'):
+                        print(f"JUPYTER_CONFIG_PATH is set to '{env.get('JUPYTER_CONFIG_PATH')}', which is prepended to the config path list (unless JUPYTER_NO_CONFIG is set)")
+                    else:
+                        print("JUPYTER_CONFIG_PATH is not set, so we do not prepend anything to the default config paths")
+
+                    if env.get('JUPYTER_CONFIG_DIR'):
+                        print(f"JUPYTER_CONFIG_DIR is set to '{env.get('JUPYTER_CONFIG_DIR')}', overriding the default user-level config directory")
+                    else:
+                        print("JUPYTER_CONFIG_DIR is not set, so we use the default user-level config directory")
+
+                    # data path list
+                    if env.get('JUPYTER_PATH'):
+                        print(f"JUPYTER_PATH is set to '{env.get('JUPYTER_PATH')}', which is prepended to the data paths")
+                    else:
+                        print("JUPYTER_PATH is not set, so we use the default data paths")
+
+                    if env.get('JUPYTER_DATA_DIR'):
+                        print(f"JUPYTER_DATA_DIR is set to '{env.get('JUPYTER_DATA_DIR')}', overriding the default user-level data directory")
+                    else:
+                        print("JUPYTER_DATA_DIR is not set, so we use the default user-level data directory")
+
+                    # runtime directory
+                    if env.get('JUPYTER_RUNTIME_DIR'):
+                        print(f"JUPYTER_RUNTIME_DIR is set to '{env.get('JUPYTER_RUNTIME_DIR')}', overriding the default runtime directory")
+                    else:
+                        print("JUPYTER_RUNTIME_DIR is not set, so we use the default runtime directory")
+
+                    print()
+
                 for name in sorted(data):
                     path = data[name]
                     print('%s:' % name)

--- a/jupyter_core/command.py
+++ b/jupyter_core/command.py
@@ -245,7 +245,7 @@ def main():
                     if env.get('JUPYTER_CONFIG_PATH'):
                         print(f"JUPYTER_CONFIG_PATH is set to '{env.get('JUPYTER_CONFIG_PATH')}', which is prepended to the config path list (unless JUPYTER_NO_CONFIG is set)")
                     else:
-                        print("JUPYTER_CONFIG_PATH is not set, so we do not prepend anything to the default config paths")
+                        print("JUPYTER_CONFIG_PATH is not set, so we do not prepend anything to the config paths")
 
                     if env.get('JUPYTER_CONFIG_DIR'):
                         print(f"JUPYTER_CONFIG_DIR is set to '{env.get('JUPYTER_CONFIG_DIR')}', overriding the default user-level config directory")
@@ -256,7 +256,7 @@ def main():
                     if env.get('JUPYTER_PATH'):
                         print(f"JUPYTER_PATH is set to '{env.get('JUPYTER_PATH')}', which is prepended to the data paths")
                     else:
-                        print("JUPYTER_PATH is not set, so we use the default data paths")
+                        print("JUPYTER_PATH is not set, so we do not prepend anything to the data paths")
 
                     if env.get('JUPYTER_DATA_DIR'):
                         print(f"JUPYTER_DATA_DIR is set to '{env.get('JUPYTER_DATA_DIR')}', overriding the default user-level data directory")

--- a/jupyter_core/paths.py
+++ b/jupyter_core/paths.py
@@ -24,7 +24,7 @@ pjoin = os.path.join
 # It is used by BSD to indicate hidden files.
 UF_HIDDEN = getattr(stat, 'UF_HIDDEN', 32768)
 
-JUPYTER_ENV_PRIORITY = bool(os.environ.get('JUPYTER_ENV_PRIORITY'))
+JUPYTER_ENV_PRIORITY = os.environ.get('JUPYTER_ENV_PRIORITY', 'n').lower() not in ['no', 'n', 'false', 'off', '0', '0.0']
 
 
 def get_home_dir():

--- a/jupyter_core/paths.py
+++ b/jupyter_core/paths.py
@@ -190,8 +190,8 @@ ENV_CONFIG_PATH = [os.path.join(sys.prefix, 'etc', 'jupyter')]
 def jupyter_config_path():
     """Return the search path for Jupyter config files as a list.
     
-    If JUPYTER_ENV_PRIORITY is set, the environment-level directories
-    will have priority over user-level directories.
+    If the JUPYTER_ENV_PRIORITY environment variable is set, the environment-level
+    directories will have priority over user-level directories.
     """
     if os.environ.get('JUPYTER_NO_CONFIG'):
         return [jupyter_config_dir()]

--- a/jupyter_core/paths.py
+++ b/jupyter_core/paths.py
@@ -24,8 +24,9 @@ pjoin = os.path.join
 # It is used by BSD to indicate hidden files.
 UF_HIDDEN = getattr(stat, 'UF_HIDDEN', 32768)
 
-JUPYTER_ENV_PRIORITY = os.environ.get('JUPYTER_ENV_PRIORITY', 'n').lower() not in ['no', 'n', 'false', 'off', '0', '0.0']
 
+# True if environment variable is set to anything besides no, n, false, off, 0, or 0.0 (case insensitive)
+JUPYTER_PREFER_ENV_PATH = os.environ.get('JUPYTER_PREFER_ENV_PATH', 'n').lower() not in ['no', 'n', 'false', 'off', '0', '0.0']
 
 def get_home_dir():
     """Get the real path of the home directory"""
@@ -132,7 +133,7 @@ def jupyter_path(*subdirs):
 
     JUPYTER_PATH environment variable has highest priority.
 
-    If the JUPYTER_ENV_PRIORITY environment variable is set, the environment-level
+    If the JUPYTER_PREFER_ENV_PATH environment variable is set, the environment-level
     directories will have priority over user-level directories.
 
     If ``*subdirs`` are given, that subdirectory will be added to each element.
@@ -156,7 +157,7 @@ def jupyter_path(*subdirs):
     user = jupyter_data_dir()
     env = [p for p in ENV_JUPYTER_PATH if p not in SYSTEM_JUPYTER_PATH]
 
-    if JUPYTER_ENV_PRIORITY:
+    if JUPYTER_PREFER_ENV_PATH:
         paths.extend(env)
         paths.append(user)
     else:
@@ -190,7 +191,7 @@ ENV_CONFIG_PATH = [os.path.join(sys.prefix, 'etc', 'jupyter')]
 def jupyter_config_path():
     """Return the search path for Jupyter config files as a list.
     
-    If the JUPYTER_ENV_PRIORITY environment variable is set, the environment-level
+    If the JUPYTER_PREFER_ENV_PATH environment variable is set, the environment-level
     directories will have priority over user-level directories.
     """
     if os.environ.get('JUPYTER_NO_CONFIG'):
@@ -207,7 +208,7 @@ def jupyter_config_path():
     user = jupyter_config_dir()
     env = [p for p in ENV_CONFIG_PATH if p not in SYSTEM_CONFIG_PATH]
 
-    if JUPYTER_ENV_PRIORITY:
+    if JUPYTER_PREFER_ENV_PATH:
         paths.extend(env)
         paths.append(user)
     else:

--- a/jupyter_core/paths.py
+++ b/jupyter_core/paths.py
@@ -25,8 +25,13 @@ pjoin = os.path.join
 UF_HIDDEN = getattr(stat, 'UF_HIDDEN', 32768)
 
 
-# True if environment variable is set to anything besides no, n, false, off, 0, or 0.0 (case insensitive)
-JUPYTER_PREFER_ENV_PATH = os.environ.get('JUPYTER_PREFER_ENV_PATH', 'n').lower() not in ['no', 'n', 'false', 'off', '0', '0.0']
+def envset(name):
+    """Return True if the given environment variable is set
+
+    An environment variable is considered set if it is assigned to a value
+    other than 'no', 'n', 'false', 'off', '0', or '0.0' (case insensitive)
+    """
+    return os.environ.get(name, 'no').lower() not in ['no', 'n', 'false', 'off', '0', '0.0']
 
 def get_home_dir():
     """Get the real path of the home directory"""
@@ -58,7 +63,7 @@ def jupyter_config_dir():
     env = os.environ
     home_dir = get_home_dir()
 
-    if env.get('JUPYTER_NO_CONFIG'):
+    if envset('JUPYTER_NO_CONFIG'):
         return _mkdtemp_once('jupyter-clean-cfg')
 
     if env.get('JUPYTER_CONFIG_DIR'):
@@ -159,7 +164,7 @@ def jupyter_path(*subdirs):
     user = jupyter_data_dir()
     env = [p for p in ENV_JUPYTER_PATH if p not in SYSTEM_JUPYTER_PATH]
 
-    if JUPYTER_PREFER_ENV_PATH:
+    if envset('JUPYTER_PREFER_ENV_PATH'):
         paths.extend(env)
         paths.append(user)
     else:
@@ -196,7 +201,7 @@ def jupyter_config_path():
     If the JUPYTER_PREFER_ENV_PATH environment variable is set, the environment-level
     directories will have priority over user-level directories.
     """
-    if os.environ.get('JUPYTER_NO_CONFIG'):
+    if envset('JUPYTER_NO_CONFIG'):
         # jupyter_config_dir makes a blank config when JUPYTER_NO_CONFIG is set.
         return [jupyter_config_dir()]
 
@@ -213,7 +218,7 @@ def jupyter_config_path():
     user = jupyter_config_dir()
     env = [p for p in ENV_CONFIG_PATH if p not in SYSTEM_CONFIG_PATH]
 
-    if JUPYTER_PREFER_ENV_PATH:
+    if envset('JUPYTER_PREFER_ENV_PATH'):
         paths.extend(env)
         paths.append(user)
     else:

--- a/jupyter_core/paths.py
+++ b/jupyter_core/paths.py
@@ -147,13 +147,15 @@ def jupyter_path(*subdirs):
     """
 
     paths = []
-    # highest priority is env
+
+    # highest priority is explicit environment variable
     if os.environ.get('JUPYTER_PATH'):
         paths.extend(
             p.rstrip(os.sep)
             for p in os.environ['JUPYTER_PATH'].split(os.pathsep)
         )
 
+    # Next is environment or user, depending on the JUPYTER_PREFER_ENV_PATH flag
     user = jupyter_data_dir()
     env = [p for p in ENV_JUPYTER_PATH if p not in SYSTEM_JUPYTER_PATH]
 
@@ -195,16 +197,19 @@ def jupyter_config_path():
     directories will have priority over user-level directories.
     """
     if os.environ.get('JUPYTER_NO_CONFIG'):
+        # jupyter_config_dir makes a blank config when JUPYTER_NO_CONFIG is set.
         return [jupyter_config_dir()]
 
     paths = []
-    # highest priority is env
+
+    # highest priority is explicit environment variable
     if os.environ.get('JUPYTER_CONFIG_PATH'):
         paths.extend(
             p.rstrip(os.sep)
             for p in os.environ['JUPYTER_CONFIG_PATH'].split(os.pathsep)
         )
 
+    # Next is environment or user, depending on the JUPYTER_PREFER_ENV_PATH flag
     user = jupyter_config_dir()
     env = [p for p in ENV_CONFIG_PATH if p not in SYSTEM_CONFIG_PATH]
 
@@ -215,6 +220,7 @@ def jupyter_config_path():
         paths.append(user)
         paths.extend(env)
 
+    # Finally, system path
     paths.extend(SYSTEM_CONFIG_PATH)
     return paths
 

--- a/jupyter_core/tests/test_command.py
+++ b/jupyter_core/tests/test_command.py
@@ -82,7 +82,12 @@ def test_paths_json():
 def test_paths_debug():
     with patch.dict('os.environ', {'JUPYTER_PREFER_ENV_PATH': 'y'}):
         output = get_jupyter_output(['--paths', '--debug'])
-    assert 'JUPYTER_PREFER_ENV_PATH' in output
+    assert 'JUPYTER_PREFER_ENV_PATH is set' in output
+
+def test_paths_debug2():
+    output = get_jupyter_output(['--paths', '--debug'])
+    assert 'JUPYTER_PREFER_ENV_PATH is not set' in output
+
 
 def test_subcommand_not_given():
     with pytest.raises(CalledProcessError):

--- a/jupyter_core/tests/test_command.py
+++ b/jupyter_core/tests/test_command.py
@@ -79,6 +79,10 @@ def test_paths_json():
     for key, path in data.items():
         assert isinstance(path, list)
 
+def test_paths_debug():
+    with patch.dict('os.environ', {'JUPYTER_PREFER_ENV_PATH': 'y'}):
+        output = get_jupyter_output(['--paths', '--debug'])
+    assert 'JUPYTER_PREFER_ENV_PATH' in output
 
 def test_subcommand_not_given():
     with pytest.raises(CalledProcessError):

--- a/jupyter_core/tests/test_command.py
+++ b/jupyter_core/tests/test_command.py
@@ -80,14 +80,23 @@ def test_paths_json():
         assert isinstance(path, list)
 
 def test_paths_debug():
-    with patch.dict('os.environ', {'JUPYTER_PREFER_ENV_PATH': 'y'}):
-        output = get_jupyter_output(['--paths', '--debug'])
-    assert 'JUPYTER_PREFER_ENV_PATH is set' in output
-
-def test_paths_debug2():
+    vars = [
+        'JUPYTER_PREFER_ENV_PATH',
+        'JUPYTER_NO_CONFIG',
+        'JUPYTER_CONFIG_PATH',
+        'JUPYTER_CONFIG_DIR',
+        'JUPYTER_PATH',
+        'JUPYTER_DATA_DIR',
+        'JUPYTER_RUNTIME_DIR'
+        ]
     output = get_jupyter_output(['--paths', '--debug'])
-    assert 'JUPYTER_PREFER_ENV_PATH is not set' in output
+    for v in vars:
+        assert f"{v} is not set" in output
 
+    with patch.dict('os.environ', [(v, 'y') for v in vars]):
+        output = get_jupyter_output(['--paths', '--debug'])
+    for v in vars:
+        assert f"{v} is set" in output
 
 def test_subcommand_not_given():
     with pytest.raises(CalledProcessError):

--- a/jupyter_core/tests/test_paths.py
+++ b/jupyter_core/tests/test_paths.py
@@ -173,7 +173,6 @@ def test_jupyter_path():
 
 def test_jupyter_path():
     with patch.object(paths, 'JUPYTER_PREFER_ENV_PATH', True):
-        print(os.environ.get('JUPYTER_PREFER_ENV_PATH'))
         path = jupyter_path()
     assert path[0] == paths.ENV_JUPYTER_PATH[0]
     assert path[1] == jupyter_data_dir()
@@ -202,7 +201,6 @@ def test_jupyter_path_subdir():
 
 def test_jupyter_config_path():
     with patch.object(paths, 'JUPYTER_PREFER_ENV_PATH', True):
-        print(os.environ.get('JUPYTER_PREFER_ENV_PATH'))
         path = jupyter_config_path()
     assert path[0] == paths.ENV_CONFIG_PATH[0]
     assert path[1] == jupyter_config_dir()

--- a/jupyter_core/tests/test_paths.py
+++ b/jupyter_core/tests/test_paths.py
@@ -15,7 +15,7 @@ import sys
 from jupyter_core import paths
 from jupyter_core.paths import (
     jupyter_config_dir, jupyter_data_dir, jupyter_runtime_dir,
-    jupyter_path, ENV_JUPYTER_PATH,
+    jupyter_path, jupyter_config_path, ENV_JUPYTER_PATH,
     secure_write, is_hidden, is_file_hidden
 )
 from tempfile import TemporaryDirectory
@@ -171,6 +171,12 @@ def test_jupyter_path():
     assert path[0] == jupyter_data_dir()
     assert path[-2:] == system_path
 
+def test_jupyter_path():
+    with patch.object(paths, 'JUPYTER_ENV_PRIORITY', True):
+        print(os.environ.get('JUPYTER_ENV_PRIORITY'))
+        path = jupyter_path()
+    assert path[0] == paths.ENV_JUPYTER_PATH[0]
+    assert path[1] == jupyter_data_dir()
 
 def test_jupyter_path_env():
     path_env = os.pathsep.join([
@@ -194,6 +200,22 @@ def test_jupyter_path_subdir():
     for p in path:
         assert p.endswith(pjoin('', 'sub1', 'sub2'))
 
+def test_jupyter_config_path():
+    with patch.object(paths, 'JUPYTER_ENV_PRIORITY', True):
+        print(os.environ.get('JUPYTER_ENV_PRIORITY'))
+        path = jupyter_config_path()
+    assert path[0] == paths.ENV_CONFIG_PATH[0]
+    assert path[1] == jupyter_config_dir()
+
+def test_jupyter_config_path_env():
+    path_env = os.pathsep.join([
+        pjoin('foo', 'bar'),
+        pjoin('bar', 'baz', ''), # trailing /
+    ])
+
+    with patch.dict('os.environ', {'JUPYTER_CONFIG_PATH': path_env}):
+        path = jupyter_config_path()
+    assert path[:2] == [pjoin('foo', 'bar'), pjoin('bar', 'baz')]
 
 def test_is_hidden():
     with TemporaryDirectory() as root:

--- a/jupyter_core/tests/test_paths.py
+++ b/jupyter_core/tests/test_paths.py
@@ -172,8 +172,8 @@ def test_jupyter_path():
     assert path[-2:] == system_path
 
 def test_jupyter_path():
-    with patch.object(paths, 'JUPYTER_ENV_PRIORITY', True):
-        print(os.environ.get('JUPYTER_ENV_PRIORITY'))
+    with patch.object(paths, 'JUPYTER_PREFER_ENV_PATH', True):
+        print(os.environ.get('JUPYTER_PREFER_ENV_PATH'))
         path = jupyter_path()
     assert path[0] == paths.ENV_JUPYTER_PATH[0]
     assert path[1] == jupyter_data_dir()
@@ -201,8 +201,8 @@ def test_jupyter_path_subdir():
         assert p.endswith(pjoin('', 'sub1', 'sub2'))
 
 def test_jupyter_config_path():
-    with patch.object(paths, 'JUPYTER_ENV_PRIORITY', True):
-        print(os.environ.get('JUPYTER_ENV_PRIORITY'))
+    with patch.object(paths, 'JUPYTER_PREFER_ENV_PATH', True):
+        print(os.environ.get('JUPYTER_PREFER_ENV_PATH'))
         path = jupyter_config_path()
     assert path[0] == paths.ENV_CONFIG_PATH[0]
     assert path[1] == jupyter_config_dir()

--- a/jupyter_core/tests/test_paths.py
+++ b/jupyter_core/tests/test_paths.py
@@ -56,6 +56,16 @@ def realpath(path):
 home_jupyter = realpath('~/.jupyter')
 
 
+def test_envset():
+    true_values = ['', 'True', 'on', 'yes', 'Y', '1', 'anything']
+    false_values = ['n', 'No', 'N', 'fAlSE', '0', '0.0', 'Off']
+    with patch.dict('os.environ', ((f"FOO_{v}", v) for v in true_values + false_values)):
+        for v in true_values:
+            assert paths.envset(f"FOO_{v}")
+        for v in false_values:
+            assert not paths.envset(f"FOO_{v}")
+        assert not paths.envset("THIS_VARIABLE_SHOULD_NOT_BE_SET")
+
 def test_config_dir_darwin():
     with darwin, no_config_env:
         config = jupyter_config_dir()
@@ -171,8 +181,8 @@ def test_jupyter_path():
     assert path[0] == jupyter_data_dir()
     assert path[-2:] == system_path
 
-def test_jupyter_path():
-    with patch.object(paths, 'JUPYTER_PREFER_ENV_PATH', True):
+def test_jupyter_path_prefer_env():
+    with patch.dict('os.environ', {'JUPYTER_PREFER_ENV_PATH': 'true'}):
         path = jupyter_path()
     assert path[0] == paths.ENV_JUPYTER_PATH[0]
     assert path[1] == jupyter_data_dir()
@@ -200,7 +210,12 @@ def test_jupyter_path_subdir():
         assert p.endswith(pjoin('', 'sub1', 'sub2'))
 
 def test_jupyter_config_path():
-    with patch.object(paths, 'JUPYTER_PREFER_ENV_PATH', True):
+    path = jupyter_config_path()
+    assert path[0] == jupyter_config_dir()
+    assert path[1] == paths.ENV_CONFIG_PATH[0]
+
+def test_jupyter_config_path_prefer_env():
+    with patch.dict('os.environ', {'JUPYTER_PREFER_ENV_PATH': 'true'}):
         path = jupyter_config_path()
     assert path[0] == paths.ENV_CONFIG_PATH[0]
     assert path[1] == jupyter_config_dir()


### PR DESCRIPTION
This addresses the long-standing problem we have when running Jupyter in virtual environments, where a given user will have many virtual environments. In this case, conceptually the environment-level paths are more specific than user-level paths, but Jupyter still treats the user-level paths as more specific. If a user typically uses virtual environments, they can set this flag in their environment and Jupyter will prioritize environment-level paths over user-level paths.

So now, setting `JUPYTER_ENV_PRIORITY` environment variable to anything except 'n', 'no', 'false', 'off', '0', or '0.0' makes Jupyter use environment paths first, *then* user-level paths (including JUPYTER_DATA_DIR or JUPYTER_CONFIG_DIR, if specified), then system locations.

We also fix an inconsistency between JUPYTER_PATH and JUPYTER_CONFIG_PATH, so that JUPYTER_CONFIG_PATH now takes priority over the user-level config directory, as happens for JUPYTER_PATH.

Questions about implementation:
1. The environment variable name is JUPYTER_ENV_PRIORITY. I don't particularly like this name. Any other suggestions?
2. ~~To determine if the variable is set (as a boolean flag), I use `bool(os.environ.get('JUPYTER_ENV_PRIORITY'))`. Is this a normal convention? For example, any nonempty string will act as true (even "false" or "False"), but the empty string will count as false. This seems a bit confusing. How should environment variables that are binary flags work?~~ *Edit: I fixed this in a later commit: False is case insensitive no|n|false|off|0|0.0, and true is anything else.*

- [x] Add tests