### PR TITLE
Fix python 3 requirements

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ classifiers      =
 py_modules = jupyter
 packages = jupyter_core, jupyter_core.utils, jupyter_core.tests
 include_package_data = True
-python_requires = !=3.0, !=3.1, !=3.2, !=3.3, !=3.4
+python_requires = >=3.5
 install_requires =
     traitlets
     pywin32>=1.0 ; sys_platform == 'win32'
@@ -31,5 +31,3 @@ console_scripts =
     jupyter-migrate      = jupyter_core.migrate:main
     jupyter-troubleshoot = jupyter_core.troubleshoot:main
 
-[bdist_wheel]
-universal=1


### PR DESCRIPTION
Even though python 3.5 is EOL now, it did just have its final release a month ago, and we do not actually have 3.6-specific code, so it seems nice to those still migrating off of 3.5 to let them have the other features the next release brings.