### PR TITLE
Revert the change to parsing in JUPYTER_NO_CONFIG in #199

### DIFF
--- a/jupyter_core/command.py
+++ b/jupyter_core/command.py
@@ -237,7 +237,7 @@ def main():
                         print("JUPYTER_PREFER_ENV_PATH is not set, making the user-level path preferred over the environment-level path for data and config")
 
                     # config path list
-                    if paths.envset('JUPYTER_NO_CONFIG'):
+                    if env.get('JUPYTER_NO_CONFIG'):
                         print("JUPYTER_NO_CONFIG is set, making the config path list only a single temporary directory")
                     else:
                         print("JUPYTER_NO_CONFIG is not set, so we use the full path list for config")

--- a/jupyter_core/paths.py
+++ b/jupyter_core/paths.py
@@ -62,7 +62,7 @@ def jupyter_config_dir():
     env = os.environ
     home_dir = get_home_dir()
 
-    if envset('JUPYTER_NO_CONFIG'):
+    if env.get('JUPYTER_NO_CONFIG'):
         return _mkdtemp_once('jupyter-clean-cfg')
 
     if env.get('JUPYTER_CONFIG_DIR'):
@@ -200,7 +200,7 @@ def jupyter_config_path():
     If the JUPYTER_PREFER_ENV_PATH environment variable is set, the environment-level
     directories will have priority over user-level directories.
     """
-    if envset('JUPYTER_NO_CONFIG'):
+    if os.environ.get('JUPYTER_NO_CONFIG'):
         # jupyter_config_dir makes a blank config when JUPYTER_NO_CONFIG is set.
         return [jupyter_config_dir()]
 


### PR DESCRIPTION
That was technically a breaking change, so should not have been done in a minor release.

We can make all environment variable boolean flags consistent in 5.0.

@kevin-bates - after thinking more about this, I think we should play it very safe and conservative here, and preserve behavior until 5.0.
