### PR TITLE
Make dev releases follow pep 440

### DIFF
--- a/jupyter_core/version.py
+++ b/jupyter_core/version.py
@@ -8,18 +8,21 @@ VersionInfo = namedtuple('VersionInfo', [
     'minor',
     'micro',
     'releaselevel',
-    'serial'
+    'serial',
+    'development',
+    'developmentserial'
 ])
 
-version_info = VersionInfo(4, 6, 4, 'dev', 0)
+version_info = VersionInfo(4, 6, 4, 'final', 0, development=True, developmentserial=0)
 
-_specifier_ = {'alpha': 'a', 'beta': 'b', 'candidate': 'rc', 'final': '', 'dev': 'dev'}
+_specifier_ = {'alpha': 'a', 'beta': 'b', 'candidate': 'rc'}
 
-if version_info.releaselevel == 'final'
-    _suffix_ = ''
-elif version_info.releaselevel == 'dev':
-    _suffix_ = f'.dev{version_info.serial}'
-else:
-    _suffix_ = f'{_specifier_[version_info.releaselevel]}{version_info.serial}'
+_suffix_ = ''
+
+if version_info.releaselevel != 'final':
+    _suffix_ += f'{_specifier_[version_info.releaselevel]}{version_info.serial}'
+
+if version_info.development:
+    _suffix_ += f'.dev{version_info.developmentserial}'
 
 __version__ = f'{version_info.major}.{version_info.minor}.{version_info.micro}{_suffix_}'


### PR DESCRIPTION
This follows on #204 (and it includes it, mostly) to make dev alpha/beta/rc releases possible, as pep440 indicates should be possible.

This also complicates the version info and file more. It also disrupts the existing convention that `version_info[3] == 'dev'` during a dev release, so it may not be considered backwards compatible. So we need to decide if this extra capability is worth it, and if so, should it be released in a major version.

Or we decide it isn't worth the extra complexity and close this pr.