### PR TITLE
[win32_restrict_file_to_user] allow user to delete file

### DIFF
--- a/jupyter_core/paths.py
+++ b/jupyter_core/paths.py
@@ -396,7 +396,7 @@ def win32_restrict_file_to_user(fname):
 
     dacl = win32security.ACL()
     # dacl.AddAccessAllowedAce(win32security.ACL_REVISION, con.FILE_ALL_ACCESS, everyone)
-    dacl.AddAccessAllowedAce(win32security.ACL_REVISION, con.FILE_GENERIC_READ | con.FILE_GENERIC_WRITE, user)
+    dacl.AddAccessAllowedAce(win32security.ACL_REVISION, con.FILE_GENERIC_READ | con.FILE_GENERIC_WRITE | con.DELETE, user)
     dacl.AddAccessAllowedAce(win32security.ACL_REVISION, con.FILE_ALL_ACCESS, admins)
 
     sd.SetSecurityDescriptorDacl(1, dacl, 0)

--- a/jupyter_core/tests/test_paths.py
+++ b/jupyter_core/tests/test_paths.py
@@ -294,7 +294,7 @@ def test_secure_write_win32():
         permissions = fetch_win32_permissions(fname)
         print(permissions) # for easier debugging
         assert username in permissions
-        assert permissions[username] == set(['r', 'w'])
+        assert permissions[username] == set(['r', 'w', 'd'])
         assert 'administrators' in permissions
         assert permissions['administrators'] == set(['f'])
         assert 'everyone' not in permissions


### PR DESCRIPTION
This allows the user to delete the file without elevating / UAC, c.f. https://docs.microsoft.com/en-us/windows/win32/fileio/file-security-and-access-rights