### PR TITLE
Command not found will no longer traceback

### DIFF
--- a/jupyter_core/command.py
+++ b/jupyter_core/command.py
@@ -282,7 +282,10 @@ def main():
         parser.print_usage(file=sys.stderr)
         sys.exit("subcommand is required")
 
-    command = _jupyter_abspath(subcommand)
+    try:
+        command = _jupyter_abspath(subcommand)
+    except Exception as e:
+        sys.exit(e)
 
     try:
         _execvp(command, sys.argv[1:])


### PR DESCRIPTION
Previously, when a command was not found, Jupyter printed a traceback on the user:

    $ jupyter foobar
    Traceback (most recent call last):
      File "/usr/bin/jupyter", line 33, in <module>
        sys.exit(load_entry_point('jupyter-core==4.6.3', 'console_scripts', 'jupyter')())
      File "/usr/lib/python3.9/site-packages/jupyter_core/command.py", line 247, in main
        command = _jupyter_abspath(subcommand)
      File "/usr/lib/python3.9/site-packages/jupyter_core/command.py", line 133, in _jupyter_abspath
        raise Exception(
    Exception: Jupyter command `jupyter-foobar` not found.

Generally, I believe users should only see tracebacks when they are debugging
stuff or when there is an unexpected "crash".

In Fedora, such traceback is detected as crash by the automatic bug reporting tool.

Now, an error message is printed to stderr instead to provide a better UX.

Fixes https://github.com/jupyter/jupyter_core/issues/211