### PR TITLE
Return canonical path when using %APPDATA% on NT

### DIFF
--- a/jupyter_core/paths.py
+++ b/jupyter_core/paths.py
@@ -14,6 +14,7 @@ import stat
 import errno
 import tempfile
 import warnings
+from pathlib import Path
 
 from contextlib import contextmanager
 
@@ -37,7 +38,7 @@ def get_home_dir():
     homedir = os.path.expanduser('~')
     # Next line will make things work even when /home/ is a symlink to
     # /usr/home as it is on FreeBSD, for example
-    homedir = os.path.realpath(homedir)
+    homedir = str(Path(homedir).resolve())
     return homedir
 
 _dtemps = {}
@@ -90,7 +91,7 @@ def jupyter_data_dir():
     elif os.name == 'nt':
         appdata = os.environ.get('APPDATA', None)
         if appdata:
-            return os.path.realpath(pjoin(appdata, 'jupyter'))
+            return str(Path(appdata, 'jupyter').resolve())
         else:
             return pjoin(jupyter_config_dir(), 'data')
     else:

--- a/jupyter_core/paths.py
+++ b/jupyter_core/paths.py
@@ -90,7 +90,7 @@ def jupyter_data_dir():
     elif os.name == 'nt':
         appdata = os.environ.get('APPDATA', None)
         if appdata:
-            return pjoin(appdata, 'jupyter')
+            return os.path.realpath(pjoin(appdata, 'jupyter'))
         else:
             return pjoin(jupyter_config_dir(), 'data')
     else:

--- a/jupyter_core/tests/mocking.py
+++ b/jupyter_core/tests/mocking.py
@@ -29,8 +29,3 @@ linux = MultiPatch(
     patch.object(os, 'name', 'posix'),
     patch.object(sys, 'platform', 'linux2'),
 )
-
-windows = MultiPatch(
-    patch.object(os, 'name', 'nt'),
-    patch.object(sys, 'platform', 'win32'),
-)

--- a/jupyter_core/tests/test_paths.py
+++ b/jupyter_core/tests/test_paths.py
@@ -116,12 +116,12 @@ def test_data_dir_darwin():
 def test_data_dir_windows():
     with windows, appdata:
         data = jupyter_data_dir()
-    assert data == pjoin('appdata', 'jupyter')
+    assert data == realpath(pjoin('appdata', 'jupyter'))
 
     with windows, appdata, xdg:
         # windows should ignore xdg
         data = jupyter_data_dir()
-    assert data == pjoin('appdata', 'jupyter')
+    assert data == realpath(pjoin('appdata', 'jupyter'))
 
 
 def test_data_dir_linux():
@@ -155,12 +155,12 @@ def test_runtime_dir_darwin():
 def test_runtime_dir_windows():
     with windows, appdata:
         runtime = jupyter_runtime_dir()
-    assert runtime == pjoin('appdata', 'jupyter', 'runtime')
+    assert runtime == realpath(pjoin('appdata', 'jupyter', 'runtime'))
 
     with windows, appdata, xdg:
         # windows should ignore xdg
         runtime = jupyter_runtime_dir()
-    assert runtime == pjoin('appdata', 'jupyter', 'runtime')
+    assert runtime == realpath(pjoin('appdata', 'jupyter', 'runtime'))
 
 
 def test_runtime_dir_linux():

--- a/jupyter_core/tests/test_paths.py
+++ b/jupyter_core/tests/test_paths.py
@@ -50,7 +50,7 @@ config_env = patch.dict('os.environ', {'JUPYTER_CONFIG_DIR': jupyter_config_env}
 
 
 def realpath(path):
-    return os.path.realpath(os.path.expanduser(path))
+    return os.path.abspath(os.path.realpath(os.path.expanduser(path)))
 
 home_jupyter = realpath('~/.jupyter')
 
@@ -119,11 +119,13 @@ def test_data_dir_darwin():
 def test_data_dir_windows():
     with appdata:
         data = jupyter_data_dir()
+    print(data)
     assert data == realpath(pjoin('appdata', 'jupyter'))
 
     with appdata, xdg:
         # windows should ignore xdg
         data = jupyter_data_dir()
+    print(data)
     assert data == realpath(pjoin('appdata', 'jupyter'))
 
 

--- a/jupyter_core/tests/test_paths.py
+++ b/jupyter_core/tests/test_paths.py
@@ -65,6 +65,7 @@ def test_envset():
             assert not paths.envset(f"FOO_{v}")
         assert not paths.envset("THIS_VARIABLE_SHOULD_NOT_BE_SET")
 
+@pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
 def test_config_dir_darwin():
     with darwin, no_config_env:
         config = jupyter_config_dir()
@@ -85,6 +86,7 @@ def test_config_dir_windows():
     assert config == jupyter_config_env
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
 def test_config_dir_linux():
     with linux, no_config_env:
         config = jupyter_config_dir()
@@ -102,6 +104,7 @@ def test_data_dir_env():
     assert data == data_env
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
 def test_data_dir_darwin():
     with darwin:
         data = jupyter_data_dir()
@@ -124,6 +127,7 @@ def test_data_dir_windows():
     assert data == realpath(pjoin('appdata', 'jupyter'))
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
 def test_data_dir_linux():
     with linux, no_xdg:
         data = jupyter_data_dir()
@@ -141,6 +145,7 @@ def test_runtime_dir_env():
     assert runtime == rtd_env
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
 def test_runtime_dir_darwin():
     with darwin:
         runtime = jupyter_runtime_dir()
@@ -163,6 +168,7 @@ def test_runtime_dir_windows():
     assert runtime == realpath(pjoin('appdata', 'jupyter', 'runtime'))
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
 def test_runtime_dir_linux():
     with linux, no_xdg:
         runtime = jupyter_runtime_dir()

--- a/jupyter_core/tests/test_paths.py
+++ b/jupyter_core/tests/test_paths.py
@@ -36,8 +36,6 @@ no_xdg = patch.dict('os.environ', {
     'XDG_RUNTIME_DIR': '',
 })
 
-appdata = patch.dict('os.environ', {'APPDATA': 'appdata'})
-
 no_config_env = patch.dict('os.environ', {
     'JUPYTER_CONFIG_DIR': '',
     'JUPYTER_DATA_DIR': '',
@@ -117,16 +115,14 @@ def test_data_dir_darwin():
 
 @pytest.mark.skipif(sys.platform != "win32", reason="only run on windows")
 def test_data_dir_windows():
-    with appdata:
+    with windows:
         data = jupyter_data_dir()
-    print(data)
-    assert data == realpath(pjoin('appdata', 'jupyter'))
+    assert data == realpath(pjoin(os.environ.get('APPDATA', None), 'jupyter'))
 
-    with appdata, xdg:
+    with windows, xdg:
         # windows should ignore xdg
         data = jupyter_data_dir()
-    print(data)
-    assert data == realpath(pjoin('appdata', 'jupyter'))
+    assert data == realpath(pjoin(os.environ.get('APPDATA', None), 'jupyter'))
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
@@ -160,14 +156,14 @@ def test_runtime_dir_darwin():
 
 @pytest.mark.skipif(sys.platform != "win32", reason="only run on windows")
 def test_runtime_dir_windows():
-    with appdata:
+    with windows:
         runtime = jupyter_runtime_dir()
-    assert runtime == realpath(pjoin('appdata', 'jupyter', 'runtime'))
+    assert runtime == realpath(pjoin(os.environ.get('APPDATA', None), 'jupyter', 'runtime'))
 
-    with appdata, xdg:
+    with windows, xdg:
         # windows should ignore xdg
         runtime = jupyter_runtime_dir()
-    assert runtime == realpath(pjoin('appdata', 'jupyter', 'runtime'))
+    assert runtime == realpath(pjoin(os.environ.get('APPDATA', None), 'jupyter', 'runtime'))
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")

--- a/jupyter_core/tests/test_paths.py
+++ b/jupyter_core/tests/test_paths.py
@@ -19,7 +19,7 @@ from jupyter_core.paths import (
     secure_write, is_hidden, is_file_hidden
 )
 
-from .mocking import darwin, windows, linux
+from .mocking import darwin, linux
 
 pjoin = os.path.join
 
@@ -115,11 +115,10 @@ def test_data_dir_darwin():
 
 @pytest.mark.skipif(sys.platform != "win32", reason="only run on windows")
 def test_data_dir_windows():
-    with windows:
-        data = jupyter_data_dir()
+    data = jupyter_data_dir()
     assert data == realpath(pjoin(os.environ.get('APPDATA', None), 'jupyter'))
 
-    with windows, xdg:
+    with xdg:
         # windows should ignore xdg
         data = jupyter_data_dir()
     assert data == realpath(pjoin(os.environ.get('APPDATA', None), 'jupyter'))
@@ -156,11 +155,10 @@ def test_runtime_dir_darwin():
 
 @pytest.mark.skipif(sys.platform != "win32", reason="only run on windows")
 def test_runtime_dir_windows():
-    with windows:
-        runtime = jupyter_runtime_dir()
+    runtime = jupyter_runtime_dir()
     assert runtime == realpath(pjoin(os.environ.get('APPDATA', None), 'jupyter', 'runtime'))
 
-    with windows, xdg:
+    with xdg:
         # windows should ignore xdg
         runtime = jupyter_runtime_dir()
     assert runtime == realpath(pjoin(os.environ.get('APPDATA', None), 'jupyter', 'runtime'))

--- a/jupyter_core/tests/test_paths.py
+++ b/jupyter_core/tests/test_paths.py
@@ -74,23 +74,23 @@ def test_config_dir_darwin():
         config = jupyter_config_dir()
     assert config == jupyter_config_env
 
-
+@pytest.mark.skipif(sys.platform != "win32", reason="only run on windows")
 def test_config_dir_windows():
-    with windows, no_config_env:
+    with no_config_env:
         config = jupyter_config_dir()
     assert config == home_jupyter
 
-    with windows, config_env:
+    with config_env:
         config = jupyter_config_dir()
     assert config == jupyter_config_env
 
 
 def test_config_dir_linux():
-    with windows, no_config_env:
+    with linux, no_config_env:
         config = jupyter_config_dir()
     assert config == home_jupyter
 
-    with windows, config_env:
+    with linux, config_env:
         config = jupyter_config_dir()
     assert config == jupyter_config_env
 
@@ -112,13 +112,13 @@ def test_data_dir_darwin():
         data = jupyter_data_dir()
     assert data == realpath('~/Library/Jupyter')
 
-
+@pytest.mark.skipif(sys.platform != "win32", reason="only run on windows")
 def test_data_dir_windows():
-    with windows, appdata:
+    with appdata:
         data = jupyter_data_dir()
     assert data == realpath(pjoin('appdata', 'jupyter'))
 
-    with windows, appdata, xdg:
+    with appdata, xdg:
         # windows should ignore xdg
         data = jupyter_data_dir()
     assert data == realpath(pjoin('appdata', 'jupyter'))
@@ -151,13 +151,13 @@ def test_runtime_dir_darwin():
         runtime = jupyter_runtime_dir()
     assert runtime == realpath('~/Library/Jupyter/runtime')
 
-
+@pytest.mark.skipif(sys.platform != "win32", reason="only run on windows")
 def test_runtime_dir_windows():
-    with windows, appdata:
+    with appdata:
         runtime = jupyter_runtime_dir()
     assert runtime == realpath(pjoin('appdata', 'jupyter', 'runtime'))
 
-    with windows, appdata, xdg:
+    with appdata, xdg:
         # windows should ignore xdg
         runtime = jupyter_runtime_dir()
     assert runtime == realpath(pjoin('appdata', 'jupyter', 'runtime'))


### PR DESCRIPTION
This fixes starting jupyter lab and notebook on windows systems when python is installed from the Microsoft Store.
jupyterlab/jupyterlab#9250
jupyter-server/jupyter_server#435
jupyter/notebook#5996

### Background
The following runtime dir is not accessible outside of python as shown in https://github.com/jupyterlab/jupyterlab/issues/9250#issuecomment-813693491

```
runtime:
    C:\Users\bussmann\AppData\Roaming\jupyter\runtime
```

### Result
Tested on https://github.com/florianbussmann/notebook/commit/5a3be036b2d364059bdabda90fdef1a480d6a24e the runtime dir used by jupyter-core in https://github.com/florianbussmann/jupyter_core/commit/ad09dbf52ed1f66f3f090897195d2382600178a1 is accessible

```
(.venv) C:\Users\bussmann\source\florianbussmann\notebook>jupyter --paths
config:
    C:\Users\bussmann\.jupyter
    c:\users\bussmann\source\florianbussmann\notebook\.venv\etc\jupyter
    C:\ProgramData\jupyter
data:
    C:\Users\bussmann\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.9_qbz5n2kfra8p0\LocalCache\Roaming\jupyter
    c:\users\bussmann\source\florianbussmann\notebook\.venv\share\jupyter
    C:\ProgramData\jupyter
runtime:
    C:\Users\bussmann\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.9_qbz5n2kfra8p0\LocalCache\Roaming\jupyter\runtime
```


### Tests
```python
(.venv) C:\Users\bussmann\source\florianbussmann\jupyter_core>py.test -rs 
=========================================================================================== test session starts ============================================================================================
platform win32 -- Python 3.9.3, pytest-6.2.3, py-1.10.0, pluggy-0.13.1
rootdir: C:\Users\bussmann\source\florianbussmann\jupyter_core
collected 52 items

jupyter_core\tests\test_application.py ........                                                                                                                                                       [ 15%]
jupyter_core\tests\test_command.py ............                                                                                                                                                       [ 38%]
jupyter_core\tests\test_migrate.py ........                                                                                                                                                           [ 53%]
jupyter_core\tests\test_paths.py .......................s                                                                                                                                             [100%]

========================================================================================= short test summary info ========================================================================================== 
SKIPPED [1] jupyter_core\tests\test_paths.py:315: does not run on windows
====================================================================================== 51 passed, 1 skipped in 3.27s ======================================================================================= 

```