### PR TITLE
Enable appropriate permissions for CodeQL workflow

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -21,6 +21,10 @@ on:
   schedule:
     - cron: '41 6 * * 6'
 
+permissions:
+  security-events:
+    write
+
 jobs:
   analyze:
     name: Analyze


### PR DESCRIPTION
Adds permissions metadata to `codeql-analysis` workflow since organization-level permissions are read-only.