### PR TITLE
Print full usage on missing or invalid commands

### DIFF
--- a/jupyter_core/command.py
+++ b/jupyter_core/command.py
@@ -286,6 +286,9 @@ def main():
         command = _jupyter_abspath(subcommand)
     except Exception as e:
         parser.print_help(file=sys.stderr)
+        # special-case alias of "jupyter help" to "jupyter --help"
+        if subcommand == "help":
+            return
         sys.exit(e)
 
     try:

--- a/jupyter_core/command.py
+++ b/jupyter_core/command.py
@@ -37,7 +37,7 @@ def jupyter_parser():
     parser = JupyterParser(
         description="Jupyter: Interactive Computing",
     )
-    group = parser.add_mutually_exclusive_group(required=True)
+    group = parser.add_mutually_exclusive_group(required=False)
     # don't use argparse's version action because it prints to stderr on py2
     group.add_argument('--version', action='store_true',
         help="show the jupyter command's version and exit")
@@ -122,12 +122,12 @@ def _jupyter_abspath(subcommand):
     abs_path = which(jupyter_subcommand, path=search_path)
     if abs_path is None:
         raise Exception(
-            'Jupyter command `{}` not found.'.format(jupyter_subcommand)
+            '\nJupyter command `{}` not found.'.format(jupyter_subcommand)
         )
 
     if not os.access(abs_path, os.X_OK):
         raise Exception(
-            'Jupyter command `{}` is not executable.'.format(jupyter_subcommand)
+            '\nJupyter command `{}` is not executable.'.format(jupyter_subcommand)
         )
 
     return abs_path
@@ -279,12 +279,13 @@ def main():
             return
 
     if not subcommand:
-        parser.print_usage(file=sys.stderr)
-        sys.exit("subcommand is required")
+        parser.print_help(file=sys.stderr)
+        sys.exit("\nPlease specify a subcommand or one of the optional arguments.")
 
     try:
         command = _jupyter_abspath(subcommand)
     except Exception as e:
+        parser.print_help(file=sys.stderr)
         sys.exit(e)
 
     try:

--- a/jupyter_core/tests/test_command.py
+++ b/jupyter_core/tests/test_command.py
@@ -112,7 +112,7 @@ def test_subcommand_not_found():
     with pytest.raises(CalledProcessError) as excinfo:
         get_jupyter_output('nonexistant-subcommand')
     stderr = excinfo.value.stderr.decode('utf8')
-    assert stderr == 'Jupyter command `jupyter-nonexistant-subcommand` not found.' + os.linesep
+    assert 'Jupyter command `jupyter-nonexistant-subcommand` not found.' in stderr
 
 @patch.object(sys, 'argv', [__file__] + sys.argv[1:])
 def test_subcommand_list(tmpdir):


### PR DESCRIPTION

prior to this commit:

```
$ jupyter help
Jupyter command `jupyter-help` not found.
$ echo $?
1
```
and

```
$ jupyter
usage: jupyter [-h] [--version] [--config-dir] [--data-dir] [--runtime-dir]
               [--paths] [--json] [--debug]
               [subcommand]
jupyter: error: one of the arguments --version subcommand --config-dir --data-dir --runtime-dir --paths is required
$ echo $?
1
```


With this PR:
```
$ jupyter help
usage: jupyter [-h] [--version] [--config-dir] [--data-dir] [--runtime-dir]
               [--paths] [--json] [--debug]
               [subcommand]

Jupyter: Interactive Computing

positional arguments:
  subcommand     the subcommand to launch

optional arguments:
  -h, --help     show this help message and exit
  --version      show the jupyter command's version and exit
  --config-dir   show Jupyter config dir
  --data-dir     show Jupyter data dir
  --runtime-dir  show Jupyter runtime dir
  --paths        show all Jupyter paths. Add --json for machine-readable
                 format.
  --json         output paths as machine-readable json
  --debug        output debug information about paths

Available subcommands: bundlerextension migrate nbextension notebook
serverextension troubleshoot
$ echo $?
0
```

and 

```
$ jupyter
usage: jupyter [-h] [--version] [--config-dir] [--data-dir] [--runtime-dir]
               [--paths] [--json] [--debug]
               [subcommand]

Jupyter: Interactive Computing

positional arguments:
  subcommand     the subcommand to launch

optional arguments:
  -h, --help     show this help message and exit
  --version      show the jupyter command's version and exit
  --config-dir   show Jupyter config dir
  --data-dir     show Jupyter data dir
  --runtime-dir  show Jupyter runtime dir
  --paths        show all Jupyter paths. Add --json for machine-readable
                 format.
  --json         output paths as machine-readable json
  --debug        output debug information about paths

Available subcommands: bundlerextension migrate nbextension notebook
serverextension troubleshoot

Please specify a subcommand or one of the optional arguments.
$ echo $?
1
```

Closes #161 .