### PR TITLE
Remove dependency on pywin32 package on PyPy

### DIFF
--- a/jupyter_core/paths.py
+++ b/jupyter_core/paths.py
@@ -267,8 +267,14 @@ def is_file_hidden_win(abs_path, stat_res=None):
                 return False
             raise
 
-    if stat_res.st_file_attributes & stat.FILE_ATTRIBUTE_HIDDEN:
-        return True
+    try:
+        if stat_res.st_file_attributes & stat.FILE_ATTRIBUTE_HIDDEN:
+            return True
+    except AttributeError:
+        # allow AttributeError on PyPy for Windows
+        # 'stat_result' object has no attribute 'st_file_attributes'
+        # https://foss.heptapod.net/pypy/pypy/-/issues/3469
+        pass
 
     return False
 
@@ -384,7 +390,11 @@ def win32_restrict_file_to_user(fname):
     fname : unicode
         The path to the file to secure
     """
-    import win32api
+    try:
+        import win32api
+    except ImportError:
+        return _win32_restrict_file_to_user_ctypes(fname)
+
     import win32security
     import ntsecuritycon as con
 
@@ -401,6 +411,400 @@ def win32_restrict_file_to_user(fname):
 
     sd.SetSecurityDescriptorDacl(1, dacl, 0)
     win32security.SetFileSecurity(fname, win32security.DACL_SECURITY_INFORMATION, sd)
+
+
+def _win32_restrict_file_to_user_ctypes(fname):
+    """Secure a windows file to read-only access for the user.
+
+    Follows guidance from win32 library creator:
+    http://timgolden.me.uk/python/win32_how_do_i/add-security-to-a-file.html
+
+    This method should be executed against an already generated file which
+    has no secrets written to it yet.
+
+    Parameters
+    ----------
+
+    fname : unicode
+        The path to the file to secure
+    """
+    import ctypes
+    from ctypes import wintypes
+
+    advapi32 = ctypes.WinDLL('advapi32', use_last_error=True)
+    secur32 = ctypes.WinDLL('secur32', use_last_error=True)
+
+    NameSamCompatible = 2
+    WinBuiltinAdministratorsSid = 26
+    DACL_SECURITY_INFORMATION = 4
+    ACL_REVISION = 2
+    ERROR_INSUFFICIENT_BUFFER = 122
+    ERROR_MORE_DATA = 234
+
+    SYNCHRONIZE = 0x100000
+    DELETE = 0x00010000
+    STANDARD_RIGHTS_REQUIRED = 0xF0000
+    STANDARD_RIGHTS_READ = 0x20000
+    STANDARD_RIGHTS_WRITE = 0x20000
+    FILE_READ_DATA = 1
+    FILE_READ_EA = 8
+    FILE_READ_ATTRIBUTES = 128
+    FILE_WRITE_DATA = 2
+    FILE_APPEND_DATA = 4
+    FILE_WRITE_EA = 16
+    FILE_WRITE_ATTRIBUTES = 256
+    FILE_ALL_ACCESS = STANDARD_RIGHTS_REQUIRED | SYNCHRONIZE | 0x1FF
+    FILE_GENERIC_READ = (
+        STANDARD_RIGHTS_READ
+        | FILE_READ_DATA
+        | FILE_READ_ATTRIBUTES
+        | FILE_READ_EA
+        | SYNCHRONIZE
+    )
+    FILE_GENERIC_WRITE = (
+        STANDARD_RIGHTS_WRITE
+        | FILE_WRITE_DATA
+        | FILE_WRITE_ATTRIBUTES
+        | FILE_WRITE_EA
+        | FILE_APPEND_DATA
+        | SYNCHRONIZE
+    )
+
+    class ACL(ctypes.Structure):
+        _fields_ = [
+            ('AclRevision', wintypes.BYTE),
+            ('Sbz1', wintypes.BYTE),
+            ('AclSize', wintypes.WORD),
+            ('AceCount', wintypes.WORD),
+            ('Sbz2', wintypes.WORD),
+        ]
+
+    PSID = ctypes.c_void_p
+    PACL = ctypes.POINTER(ACL)
+    PSECURITY_DESCRIPTOR = ctypes.POINTER(wintypes.BYTE)
+
+    def _nonzero_success(result, func, args):
+        if not result:
+            raise ctypes.WinError(ctypes.get_last_error())
+        return args
+
+    secur32.GetUserNameExW.errcheck = _nonzero_success
+    secur32.GetUserNameExW.restype = wintypes.BOOL
+    secur32.GetUserNameExW.argtypes = (
+        ctypes.c_int,  # EXTENDED_NAME_FORMAT NameFormat
+        wintypes.LPWSTR,  # LPWSTR lpNameBuffer,
+        wintypes.PULONG,  # PULONG nSize
+    )
+
+    advapi32.CreateWellKnownSid.errcheck = _nonzero_success
+    advapi32.CreateWellKnownSid.restype = wintypes.BOOL
+    advapi32.CreateWellKnownSid.argtypes = (
+        wintypes.DWORD,  # WELL_KNOWN_SID_TYPE WellKnownSidType
+        PSID,  # PSID DomainSid
+        PSID,  # PSID pSid
+        wintypes.PDWORD,  # DWORD *cbSid
+    )
+
+    advapi32.LookupAccountNameW.errcheck = _nonzero_success
+    advapi32.LookupAccountNameW.restype = wintypes.BOOL
+    advapi32.LookupAccountNameW.argtypes = (
+        wintypes.LPWSTR,  # LPCWSTR lpSystemName
+        wintypes.LPWSTR,  # LPCWSTR lpAccountName
+        PSID,  # PSID Sid
+        wintypes.LPDWORD,  # LPDWORD cbSid
+        wintypes.LPWSTR,  # LPCWSTR ReferencedDomainName
+        wintypes.LPDWORD,  # LPDWORD cchReferencedDomainName
+        wintypes.LPDWORD,  # PSID_NAME_USE peUse
+    )
+
+    advapi32.AddAccessAllowedAce.errcheck = _nonzero_success
+    advapi32.AddAccessAllowedAce.restype = wintypes.BOOL
+    advapi32.AddAccessAllowedAce.argtypes = (
+        PACL,  # PACL pAcl
+        wintypes.DWORD,  # DWORD dwAceRevision
+        wintypes.DWORD,  # DWORD AccessMask
+        PSID,  # PSID pSid
+    )
+
+    advapi32.SetSecurityDescriptorDacl.errcheck = _nonzero_success
+    advapi32.SetSecurityDescriptorDacl.restype = wintypes.BOOL
+    advapi32.SetSecurityDescriptorDacl.argtypes = (
+        PSECURITY_DESCRIPTOR,  # PSECURITY_DESCRIPTOR pSecurityDescriptor
+        wintypes.BOOL,  # BOOL bDaclPresent
+        PACL,  # PACL pDacl
+        wintypes.BOOL,  # BOOL bDaclDefaulted
+    )
+
+    advapi32.GetFileSecurityW.errcheck = _nonzero_success
+    advapi32.GetFileSecurityW.restype = wintypes.BOOL
+    advapi32.GetFileSecurityW.argtypes = (
+        wintypes.LPCWSTR,  # LPCWSTR lpFileName
+        wintypes.DWORD,  # SECURITY_INFORMATION RequestedInformation
+        PSECURITY_DESCRIPTOR,  # PSECURITY_DESCRIPTOR pSecurityDescriptor
+        wintypes.DWORD,  # DWORD nLength
+        wintypes.LPDWORD,  # LPDWORD lpnLengthNeeded
+    )
+
+    advapi32.SetFileSecurityW.errcheck = _nonzero_success
+    advapi32.SetFileSecurityW.restype = wintypes.BOOL
+    advapi32.SetFileSecurityW.argtypes = (
+        wintypes.LPCWSTR,  # LPCWSTR lpFileName
+        wintypes.DWORD,  # SECURITY_INFORMATION SecurityInformation
+        PSECURITY_DESCRIPTOR,  # PSECURITY_DESCRIPTOR pSecurityDescriptor
+    )
+
+    advapi32.MakeAbsoluteSD.errcheck = _nonzero_success
+    advapi32.MakeAbsoluteSD.restype = wintypes.BOOL
+    advapi32.MakeAbsoluteSD.argtypes = (
+        PSECURITY_DESCRIPTOR,  # pSelfRelativeSecurityDescriptor
+        PSECURITY_DESCRIPTOR,  # pAbsoluteSecurityDescriptor
+        wintypes.LPDWORD,  # LPDWORD lpdwAbsoluteSecurityDescriptorSize
+        PACL,  # PACL pDacl
+        wintypes.LPDWORD,  # LPDWORD lpdwDaclSize
+        PACL,  # PACL pSacl
+        wintypes.LPDWORD,  # LPDWORD lpdwSaclSize
+        PSID,  # PSID pOwner
+        wintypes.LPDWORD,  # LPDWORD lpdwOwnerSize
+        PSID,  # PSID pPrimaryGroup
+        wintypes.LPDWORD,  # LPDWORD lpdwPrimaryGroupSize
+    )
+
+    advapi32.MakeSelfRelativeSD.errcheck = _nonzero_success
+    advapi32.MakeSelfRelativeSD.restype = wintypes.BOOL
+    advapi32.MakeSelfRelativeSD.argtypes = (
+        PSECURITY_DESCRIPTOR,  # pAbsoluteSecurityDescriptor
+        PSECURITY_DESCRIPTOR,  # pSelfRelativeSecurityDescriptor
+        wintypes.LPDWORD,  # LPDWORD lpdwBufferLength
+    )
+
+    advapi32.InitializeAcl.errcheck = _nonzero_success
+    advapi32.InitializeAcl.restype = wintypes.BOOL
+    advapi32.InitializeAcl.argtypes = (
+        PACL,  # PACL pAcl,
+        wintypes.DWORD,  # DWORD nAclLength,
+        wintypes.DWORD,  # DWORD dwAclRevision
+    )
+
+    def CreateWellKnownSid(WellKnownSidType):
+        # return a SID for predefined aliases
+        pSid = (ctypes.c_char * 1)()
+        cbSid = wintypes.DWORD()
+        try:
+            advapi32.CreateWellKnownSid(
+                WellKnownSidType, None, pSid, ctypes.byref(cbSid)
+            )
+        except OSError as e:
+            if e.winerror != ERROR_INSUFFICIENT_BUFFER:
+                raise
+            pSid = (ctypes.c_char * cbSid.value)()
+            advapi32.CreateWellKnownSid(
+                WellKnownSidType, None, pSid, ctypes.byref(cbSid)
+            )
+        return pSid[:]
+
+    def GetUserNameEx(NameFormat):
+        # return the user or other security principal associated with
+        # the calling thread
+        nSize = ctypes.pointer(ctypes.c_ulong(0))
+        try:
+            secur32.GetUserNameExW(NameFormat, None, nSize)
+        except WindowsError as e:
+            if e.winerror != ERROR_MORE_DATA:
+                raise
+        if not nSize.contents.value:
+            return None
+        lpNameBuffer = ctypes.create_unicode_buffer(nSize.contents.value)
+        secur32.GetUserNameExW(NameFormat, lpNameBuffer, nSize)
+        return lpNameBuffer.value
+
+    def LookupAccountName(lpSystemName, lpAccountName):
+        # return a security identifier (SID) for an account on a system
+        # and the name of the domain on which the account was found
+        cbSid = wintypes.DWORD(0)
+        cchReferencedDomainName = wintypes.DWORD(0)
+        peUse = wintypes.DWORD(0)
+        try:
+            advapi32.LookupAccountNameW(
+                lpSystemName,
+                lpAccountName,
+                None,
+                ctypes.byref(cbSid),
+                None,
+                ctypes.byref(cchReferencedDomainName),
+                ctypes.byref(peUse),
+            )
+        except WindowsError as e:
+            if e.winerror != ERROR_INSUFFICIENT_BUFFER:
+                raise
+        Sid = ctypes.create_unicode_buffer('', cbSid.value)
+        pSid = ctypes.cast(ctypes.pointer(Sid), wintypes.LPVOID)
+        lpReferencedDomainName = ctypes.create_unicode_buffer(
+            '', cchReferencedDomainName.value + 1
+        )
+        success = advapi32.LookupAccountNameW(
+            lpSystemName,
+            lpAccountName,
+            pSid,
+            ctypes.byref(cbSid),
+            lpReferencedDomainName,
+            ctypes.byref(cchReferencedDomainName),
+            ctypes.byref(peUse),
+        )
+        if not success:
+            raise ctypes.WinError()
+        return pSid, lpReferencedDomainName.value, peUse.value
+
+    def AddAccessAllowedAce(pAcl, dwAceRevision, AccessMask, pSid):
+        # add an access-allowed access control entry (ACE)
+        # to an access control list (ACL)
+        advapi32.AddAccessAllowedAce(pAcl, dwAceRevision, AccessMask, pSid)
+
+    def GetFileSecurity(lpFileName, RequestedInformation):
+        # return information about the security of a file or directory
+        nLength = wintypes.DWORD(0)
+        try:
+            advapi32.GetFileSecurityW(
+                lpFileName,
+                RequestedInformation,
+                None,
+                0,
+                ctypes.byref(nLength),
+            )
+        except WindowsError as e:
+            if e.winerror != ERROR_INSUFFICIENT_BUFFER:
+                raise
+        if not nLength.value:
+            return None
+        pSecurityDescriptor = (wintypes.BYTE * nLength.value)()
+        advapi32.GetFileSecurityW(
+            lpFileName,
+            RequestedInformation,
+            pSecurityDescriptor,
+            nLength,
+            ctypes.byref(nLength),
+        )
+        return pSecurityDescriptor
+
+    def SetFileSecurity(lpFileName, RequestedInformation, pSecurityDescriptor):
+        # set the security of a file or directory object
+        advapi32.SetFileSecurityW(
+            lpFileName, RequestedInformation, pSecurityDescriptor
+        )
+
+    def SetSecurityDescriptorDacl(
+        pSecurityDescriptor, bDaclPresent, pDacl, bDaclDefaulted
+    ):
+        # set information in a discretionary access control list (DACL)
+        advapi32.SetSecurityDescriptorDacl(
+            pSecurityDescriptor, bDaclPresent, pDacl, bDaclDefaulted
+        )
+
+    def MakeAbsoluteSD(pSelfRelativeSecurityDescriptor):
+        # return a security descriptor in absolute format
+        # by using a security descriptor in self-relative format as a template
+        pAbsoluteSecurityDescriptor = None
+        lpdwAbsoluteSecurityDescriptorSize = wintypes.DWORD(0)
+        pDacl = None
+        lpdwDaclSize = wintypes.DWORD(0)
+        pSacl = None
+        lpdwSaclSize = wintypes.DWORD(0)
+        pOwner = None
+        lpdwOwnerSize = wintypes.DWORD(0)
+        pPrimaryGroup = None
+        lpdwPrimaryGroupSize = wintypes.DWORD(0)
+        try:
+            advapi32.MakeAbsoluteSD(
+                pSelfRelativeSecurityDescriptor,
+                pAbsoluteSecurityDescriptor,
+                ctypes.byref(lpdwAbsoluteSecurityDescriptorSize),
+                pDacl,
+                ctypes.byref(lpdwDaclSize),
+                pSacl,
+                ctypes.byref(lpdwSaclSize),
+                pOwner,
+                ctypes.byref(lpdwOwnerSize),
+                pPrimaryGroup,
+                ctypes.byref(lpdwPrimaryGroupSize),
+            )
+        except WindowsError as e:
+            if e.winerror != ERROR_INSUFFICIENT_BUFFER:
+                raise
+        pAbsoluteSecurityDescriptor = (
+            wintypes.BYTE * lpdwAbsoluteSecurityDescriptorSize.value
+        )()
+        pDaclData = (wintypes.BYTE * lpdwDaclSize.value)()
+        pDacl = ctypes.cast(pDaclData, PACL).contents
+        pSaclData = (wintypes.BYTE * lpdwSaclSize.value)()
+        pSacl = ctypes.cast(pSaclData, PACL).contents
+        pOwnerData = (wintypes.BYTE * lpdwOwnerSize.value)()
+        pOwner = ctypes.cast(pOwnerData, PSID)
+        pPrimaryGroupData = (wintypes.BYTE * lpdwPrimaryGroupSize.value)()
+        pPrimaryGroup = ctypes.cast(pPrimaryGroupData, PSID)
+        advapi32.MakeAbsoluteSD(
+            pSelfRelativeSecurityDescriptor,
+            pAbsoluteSecurityDescriptor,
+            ctypes.byref(lpdwAbsoluteSecurityDescriptorSize),
+            pDacl,
+            ctypes.byref(lpdwDaclSize),
+            pSacl,
+            ctypes.byref(lpdwSaclSize),
+            pOwner,
+            lpdwOwnerSize,
+            pPrimaryGroup,
+            ctypes.byref(lpdwPrimaryGroupSize),
+        )
+        return pAbsoluteSecurityDescriptor
+
+    def MakeSelfRelativeSD(pAbsoluteSecurityDescriptor):
+        # return a security descriptor in self-relative format
+        # by using a security descriptor in absolute format as a template
+        pSelfRelativeSecurityDescriptor = None
+        lpdwBufferLength = wintypes.DWORD(0)
+        try:
+            advapi32.MakeSelfRelativeSD(
+                pAbsoluteSecurityDescriptor,
+                pSelfRelativeSecurityDescriptor,
+                ctypes.byref(lpdwBufferLength),
+            )
+        except WindowsError as e:
+            if e.winerror != ERROR_INSUFFICIENT_BUFFER:
+                raise
+        pSelfRelativeSecurityDescriptor = (
+            wintypes.BYTE * lpdwBufferLength.value
+        )()
+        advapi32.MakeSelfRelativeSD(
+            pAbsoluteSecurityDescriptor,
+            pSelfRelativeSecurityDescriptor,
+            ctypes.byref(lpdwBufferLength),
+        )
+        return pSelfRelativeSecurityDescriptor
+
+    def NewAcl():
+        # return a new, initialized ACL (access control list) structure
+        nAclLength = 32767  # TODO: calculate this: ctypes.sizeof(ACL) + ?
+        acl_data = ctypes.create_string_buffer(nAclLength)
+        pAcl = ctypes.cast(acl_data, PACL).contents
+        advapi32.InitializeAcl(pAcl, nAclLength, ACL_REVISION)
+        return pAcl
+
+    SidAdmins = CreateWellKnownSid(WinBuiltinAdministratorsSid)
+    SidUser = LookupAccountName('', GetUserNameEx(NameSamCompatible))[0]
+
+    Acl = NewAcl()
+    AddAccessAllowedAce(Acl, ACL_REVISION, FILE_ALL_ACCESS, SidAdmins)
+    AddAccessAllowedAce(
+        Acl,
+        ACL_REVISION,
+        FILE_GENERIC_READ | FILE_GENERIC_WRITE | DELETE,
+        SidUser,
+    )
+
+    SelfRelativeSD = GetFileSecurity(fname, DACL_SECURITY_INFORMATION)
+    AbsoluteSD = MakeAbsoluteSD(SelfRelativeSD)
+    SetSecurityDescriptorDacl(AbsoluteSD, 1, Acl, 0)
+    SelfRelativeSD = MakeSelfRelativeSD(AbsoluteSD)
+
+    SetFileSecurity(fname, DACL_SECURITY_INFORMATION, SelfRelativeSD)
 
 
 def get_file_mode(fname):

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ include_package_data = True
 python_requires = >=3.6
 install_requires =
     traitlets
-    pywin32>=1.0 ; sys_platform == 'win32'
+    pywin32>=1.0 ; sys_platform == 'win32' and platform_python_implementation != 'PyPy'
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
Fix #226 and #229

This PR makes `jupyter_core` compatible with PyPy on Win32.  The main issue is that the `pywin32` package does not yet support PyPy (https://github.com/mhammond/pywin32/issues/1289).

Changes:
1. add an alternative Ctypes implementation of the `win32_restrict_file_to_user` function, which is used as a fallback if the `pywin32` package is not installed
2. change `install_requires` to exclude `pywin32` on PyPy
3. allow `AttributeError: 'stat_result' object has no attribute 'st_file_attributes'` to pass silently

Tested with pypy3.7-v7.3.5.