### PR TITLE
Update packages listed in jupyter --version

### DIFF
--- a/jupyter_core/command.py
+++ b/jupyter_core/command.py
@@ -40,7 +40,7 @@ def jupyter_parser():
     group = parser.add_mutually_exclusive_group(required=False)
     # don't use argparse's version action because it prints to stderr on py2
     group.add_argument('--version', action='store_true',
-        help="show the jupyter command's version and exit")
+        help="show the versions of core jupyter packages and exit")
     group.add_argument('subcommand', type=str, nargs='?', help='the subcommand to launch')
 
     group.add_argument('--config-dir', action='store_true',
@@ -184,26 +184,31 @@ def main():
         args, opts = parser.parse_known_args()
         subcommand = args.subcommand
         if args.version:
-            print('{:<17}:'.format('jupyter core'), __version__)
-            for package, name in [
-                ('notebook', 'jupyter-notebook'),
-                ('qtconsole', 'qtconsole'),
-                ('IPython', 'ipython'),
-                ('ipykernel', 'ipykernel'),
-                ('jupyter_client', 'jupyter client'),
-                ('jupyterlab', 'jupyter lab'),
-                ('nbconvert', 'nbconvert'),
-                ('ipywidgets', 'ipywidgets'),
-                ('nbformat', 'nbformat'),
-                ('traitlets', 'traitlets'),
+            print("Selected Jupyter core packages...")
+            for package in [
+                'IPython',
+                'ipykernel',
+                'ipywidgets',
+                'jupyter_client',
+                'jupyter_core',
+                'jupyter_server',
+                'jupyterlab',
+                'nbclient',
+                'nbconvert',
+                'nbformat',
+                'notebook',
+                'qtconsole',
+                'traitlets',
             ]:
-                version = None
                 try:
-                    mod = __import__(package)
-                    version = mod.__version__
+                    if package == 'jupyter_core':  # We're already here
+                        version = __version__
+                    else:
+                        mod = __import__(package)
+                        version = mod.__version__
                 except ImportError:
                     version = 'not installed'
-                print('{:<17}:'.format(name), version)
+                print('{:<17}:'.format(package), version)
             return
         if args.json and not args.paths:
             sys.exit("--json is only used with --paths")


### PR DESCRIPTION
Seems like we should include `jupyter_server` in the `jupyter --version` output.  While updating, I made the following changes:

1. Use package names and not logical "application" names since the latter introduced inconsistencies and package names are what folks equate with version information.
2. Sort packages alphabetically
3. Add `jupyter_server` and `nbclient`
4. Add indicator that these are "selected packages" (i.e., it's not a complete list) 

Here's the before and after output (on my system)...
Before...
```
$ jupyter --version
jupyter core     : 4.7.1
jupyter-notebook : 6.2.0
qtconsole        : not installed
ipython          : 7.23.0
ipykernel        : 5.5.5
jupyter client   : 7.0.0.dev
jupyter lab      : 3.0.4
nbconvert        : 6.0.7
ipywidgets       : not installed
nbformat         : 5.1.2
traitlets        : 5.0.5
```
After...
```
$ jupyter --version
Selected Jupyter core packages...
IPython          : 7.23.0
ipykernel        : 5.5.5
ipywidgets       : not installed
jupyter_client   : 7.0.0.dev
jupyter_core     : 4.8.0.dev0
jupyter_server   : 1.9.0.dev0
jupyterlab       : 3.0.4
nbclient         : 0.5.3
nbconvert        : 6.0.7
nbformat         : 5.1.2
notebook         : 6.2.0
qtconsole        : not installed
traitlets        : 5.0.5
```
