### PR TITLE
Trigger warning when trying to check hidden file status on PyPy

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -14,12 +14,15 @@ See the `jupyter_core
 4.8 <https://github.com/jupyter/jupyter_core/milestone/20?closed=1>`__
 milestone on GitHub for the full list of pull requests and issues closed.
 
+jupyter-core now has experimental support for PyPy (Python 3.7). Some features are known not to work due to limitations in PyPy, such as hidden file detection on Windows.
+
 - Print an error message instead of an exception when a command is not found (:ghpull:`218`)
 - Return canonical path when using ``%APPDATA%`` on Windows (:ghpull:`222`)
 - Print full usage on missing or invalid commands (:ghpull:`225`)
 - Remove dependency on ``pywin32`` package on PyPy (:ghpull:`230`)
 - Update packages listed in ``jupyter --version`` (:ghpull:`232`)
 - Inherit base aliases/flags from traitlets Application, including ``--show-config`` from traitlets 5 (:ghpull:`233`)
+- Trigger warning when trying to check hidden file status on PyPy (:ghpull:`238`)
 
 4.7
 ---

--- a/jupyter_core/paths.py
+++ b/jupyter_core/paths.py
@@ -275,6 +275,7 @@ def is_file_hidden_win(abs_path, stat_res=None):
         # allow AttributeError on PyPy for Windows
         # 'stat_result' object has no attribute 'st_file_attributes'
         # https://foss.heptapod.net/pypy/pypy/-/issues/3469
+        warnings.warn("hidden files are not detectable on this system, so no file will be marked as hidden.")
         pass
 
     return False

--- a/jupyter_core/tests/test_paths.py
+++ b/jupyter_core/tests/test_paths.py
@@ -261,8 +261,8 @@ def test_is_hidden():
 
 
 @pytest.mark.skipif(
-    not (sys.platform == "win32" and "__pypy__" not in sys.modules),
-    reason="only run on windows/cpython: https://foss.heptapod.net/pypy/pypy/-/issues/3469"
+    not (sys.platform == "win32" and (("__pypy__" not in sys.modules) or (sys.implementation.version >= (7, 3, 6)))),
+    reason="only run on windows/cpython or pypy >= 7.3.6: https://foss.heptapod.net/pypy/pypy/-/issues/3469"
 )
 def test_is_hidden_win32_cpython():
     import ctypes
@@ -275,8 +275,8 @@ def test_is_hidden_win32_cpython():
         assert is_file_hidden(subdir1)
 
 @pytest.mark.skipif(
-    not (sys.platform == "win32" and "__pypy__" in sys.modules),
-    reason="only run on windows/pypy: https://foss.heptapod.net/pypy/pypy/-/issues/3469"
+    not (sys.platform == "win32" and "__pypy__" in sys.modules and sys.implementation.version < (7, 3, 6)),
+    reason="only run on windows/pypy < 7.3.6: https://foss.heptapod.net/pypy/pypy/-/issues/3469"
 )
 def test_is_hidden_win32_pypy():
     import ctypes


### PR DESCRIPTION
As discussed in #235, perhaps the best thing to do to give best-effort support for pypy and help users to understand the current limitations is to trigger a warning when we know we cannot give good results.