### PR TITLE
Fix windows test regression.

### DIFF
--- a/jupyter_core/tests/test_paths.py
+++ b/jupyter_core/tests/test_paths.py
@@ -328,7 +328,7 @@ def test_secure_write_win32():
 
     def check_user_only_permissions(fname):
         # Windows has it's own permissions ACL patterns
-        username = os.environ["USERNAME"]
+        username = os.environ["USERNAME"].lower()
         permissions = fetch_win32_permissions(fname)
         print(permissions) # for easier debugging
         assert username in permissions


### PR DESCRIPTION
Fixes https://github.com/jupyter/jupyter_core/issues/239

It looks like 2a08a19 removed the lowercasing of the username, and in this test the username is compared to the explicitly lowercased username, leading to a test failure on conda-forge.