### PR TITLE
Add explicit encoding in open calls

### DIFF
--- a/jupyter_core/application.py
+++ b/jupyter_core/application.py
@@ -147,7 +147,7 @@ class JupyterApp(Application):
             config_text = config_text.decode('utf8')
         print("Writing default config to: %s" % config_file)
         ensure_dir_exists(os.path.abspath(os.path.dirname(config_file)), 0o700)
-        with open(config_file, mode='w') as f:
+        with open(config_file, mode='w', encoding='utf-8') as f:
             f.write(config_text)
     
     def migrate_config(self):

--- a/jupyter_core/migrate.py
+++ b/jupyter_core/migrate.py
@@ -109,11 +109,11 @@ def migrate_file(src, dst, substitutions=None):
     ensure_dir_exists(os.path.dirname(dst))
     shutil.copy(src, dst)
     if substitutions:
-        with open(dst) as f:
+        with open(dst, encoding='utf-8') as f:
             text = f.read()
         for pat, replacement in substitutions.items():
             text = pat.sub(replacement, text)
-        with open(dst, 'w') as f:
+        with open(dst, 'w', encoding='utf-8') as f:
             f.write(text)
     return True
 
@@ -146,7 +146,7 @@ def migrate_static_custom(src, dst):
     # check if custom_js is empty:
     custom_js_empty = True
     if os.path.isfile(custom_js):
-        with open(custom_js) as f:
+        with open(custom_js, encoding='utf-8') as f:
             js = f.read().strip()
             for line in js.splitlines():
                 if not (
@@ -159,7 +159,7 @@ def migrate_static_custom(src, dst):
     # check if custom_css is empty:
     custom_css_empty = True
     if os.path.isfile(custom_css):
-        with open(custom_css) as f:
+        with open(custom_css, encoding='utf-8') as f:
             css = f.read().strip()
             custom_css_empty = css.startswith('/*') and css.endswith('*/')
     
@@ -242,7 +242,7 @@ def migrate():
     
     # write a marker to avoid re-running migration checks
     ensure_dir_exists(env['jupyter_config'])
-    with open(os.path.join(env['jupyter_config'], 'migrated'), 'w') as f:
+    with open(os.path.join(env['jupyter_config'], 'migrated'), 'w', encoding='utf-8') as f:
         f.write(datetime.utcnow().isoformat())
     
     return migrated

--- a/jupyter_core/paths.py
+++ b/jupyter_core/paths.py
@@ -877,6 +877,7 @@ def secure_write(fname, binary=False):
         Indicates that the file is binary
     """
     mode = 'wb' if binary else 'w'
+    encoding = None if binary else 'utf-8'
     open_flag = os.O_CREAT | os.O_WRONLY | os.O_TRUNC
     try:
         os.remove(fname)
@@ -898,7 +899,7 @@ def secure_write(fname, binary=False):
             open_flag = os.O_WRONLY | os.O_TRUNC
             win32_restrict_file_to_user(fname)
 
-    with os.fdopen(os.open(fname, open_flag, 0o0600), mode) as f:
+    with os.fdopen(os.open(fname, open_flag, 0o0600), mode, encoding=encoding) as f:
         if os.name != 'nt':
             # Enforce that the file got the requested permissions before writing
             file_mode = get_file_mode(fname)

--- a/jupyter_core/tests/test_application.py
+++ b/jupyter_core/tests/test_application.py
@@ -33,7 +33,7 @@ def test_custom_config():
     app = DummyApp()
     td = mkdtemp()
     fname = pjoin(td, 'config.py')
-    with open(fname, 'w') as f:
+    with open(fname, 'w', encoding='utf-8') as f:
         f.write(_dummy_config)
     app.initialize(['--config', fname])
     shutil.rmtree(td)
@@ -44,7 +44,7 @@ def test_cli_override():
     app = DummyApp()
     td = mkdtemp()
     fname = pjoin(td, 'config.py')
-    with open(fname, 'w') as f:
+    with open(fname, 'w', encoding='utf-8') as f:
         f.write(_dummy_config)
     app.initialize(['--config', fname, '--DummyApp.n=20'])
     shutil.rmtree(td)
@@ -66,7 +66,7 @@ def test_generate_config():
 def test_load_config():
     config_dir = mkdtemp()
     wd = mkdtemp()
-    with open(pjoin(config_dir, 'dummy_app_config.py'), 'w') as f:
+    with open(pjoin(config_dir, 'dummy_app_config.py'), 'w', encoding='utf-8') as f:
         f.write('c.DummyApp.m = 1\n')
         f.write('c.DummyApp.n = 1')
     with patch.object(os, 'getcwd', lambda : wd):
@@ -75,7 +75,7 @@ def test_load_config():
 
     assert app.n == 1, "Loaded config from config dir"
     
-    with open(pjoin(wd, 'dummy_app_config.py'), 'w') as f:
+    with open(pjoin(wd, 'dummy_app_config.py'), 'w', encoding='utf-8') as f:
         f.write('c.DummyApp.n = 2')
 
     with patch.object(os, 'getcwd', lambda : wd):
@@ -92,7 +92,7 @@ def test_load_config():
 def test_load_bad_config():
     config_dir = mkdtemp()
     wd = mkdtemp()
-    with open(pjoin(config_dir, 'dummy_app_config.py'), 'w') as f:
+    with open(pjoin(config_dir, 'dummy_app_config.py'), 'w', encoding='utf-8') as f:
         f.write('c.DummyApp.m = "a\n') # Syntax error
     with patch.object(os, 'getcwd', lambda : wd):
         with pytest.raises(SyntaxError):

--- a/jupyter_core/tests/test_migrate.py
+++ b/jupyter_core/tests/test_migrate.py
@@ -57,7 +57,7 @@ def env(request):
 
 def touch(path, content=''):
     ensure_dir_exists(os.path.dirname(path))
-    with open(path, 'w') as f:
+    with open(path, 'w', encoding='utf-8') as f:
         f.write(content)
 
 
@@ -65,10 +65,10 @@ def assert_files_equal(a, b):
     """Verify that two files match"""
     
     assert os.path.exists(b)
-    with open(a) as f:
+    with open(a, encoding='utf-8') as f:
         a_txt = f.read()
     
-    with open(b) as f:
+    with open(b, encoding='utf-8') as f:
         b_txt = f.read()
     
     assert a_txt == b_txt
@@ -166,7 +166,7 @@ def test_migrate_config(td):
         'jupyter_test_config.py',
     ]
     
-    with open(pjoin(jpy, 'jupyter_test_config.py')) as f:
+    with open(pjoin(jpy, 'jupyter_test_config.py'), encoding='utf-8') as f:
         text = f.read()
     assert text == 'c.Replaced.trait = 5\n'
 

--- a/jupyter_core/tests/test_paths.py
+++ b/jupyter_core/tests/test_paths.py
@@ -396,7 +396,7 @@ def test_secure_write_win32():
         with secure_write(fname) as f:
             f.write('test 1')
         check_user_only_permissions(fname)
-        with open(fname, 'r') as f:
+        with open(fname, 'r', encoding='utf-8') as f:
             assert f.read() == 'test 1'
     finally:
         shutil.rmtree(directory)
@@ -411,7 +411,7 @@ def test_secure_write_unix():
             f.write('test 1')
         mode = os.stat(fname).st_mode
         assert 0o0600 == (stat.S_IMODE(mode) & 0o7677)  # tolerate owner-execute bit
-        with open(fname, 'r') as f:
+        with open(fname, 'r', encoding='utf-8') as f:
             assert f.read() == 'test 1'
 
         # Try changing file permissions ahead of time
@@ -420,7 +420,7 @@ def test_secure_write_unix():
             f.write('test 2')
         mode = os.stat(fname).st_mode
         assert 0o0600 == (stat.S_IMODE(mode) & 0o7677)  # tolerate owner-execute bit
-        with open(fname, 'r') as f:
+        with open(fname, 'r', encoding='utf-8') as f:
             assert f.read() == 'test 2'
     finally:
         shutil.rmtree(directory)


### PR DESCRIPTION
Having enabled `PYTHONWARNDEFAULTENCODING` on Python 3.10, I now get yelled at (which is a good thing!) whenever Python opens a file in text mode without an encoding specified, implicitly falling back on the locale. It just happened when calling `jupyter server --generate-config`, so I took a bit of time to add explicit encoding arguments to open calls in `jupyter_core`.

Please review if UTF-8 is the appropriate encoding in all cases, I'm not otherwise familiar with the codebase, so it's not always easy for me to see. Most of the calls seem to handle Python / CSS / JS files, where UTF-8 should be appropriate, but one of the functions I'm not entirely sure about is `paths.secure_write`, which can probably be used to write lots of different files (though that in turn means it can be used to write Python files, which should be UTF-8).