### PR TITLE
jupyter_config_dir - reorder home_dir initialization

### DIFF
--- a/jupyter_core/paths.py
+++ b/jupyter_core/paths.py
@@ -62,14 +62,13 @@ def jupyter_config_dir():
     """
 
     env = os.environ
-    home_dir = get_home_dir()
-
     if env.get('JUPYTER_NO_CONFIG'):
         return _mkdtemp_once('jupyter-clean-cfg')
 
     if env.get('JUPYTER_CONFIG_DIR'):
         return env['JUPYTER_CONFIG_DIR']
 
+    home_dir = get_home_dir()
     return pjoin(home_dir, '.jupyter')
 
 


### PR DESCRIPTION
This PR moves the initialization of the home_dir variable, so that this logic will not get hit if `JUPYTER_CONFIG_DIR` or `JUPYTER_NO_CONFIG` are set in the environment (this helps to avoid any OS level issues accessing or resolving default file paths when the config directory path is already being set explicitly as an environment variable)