### PR TITLE
Include all files from `jupyter_core`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ classifiers      =
 
 [options]
 py_modules = jupyter
-packages = jupyter_core, jupyter_core.utils, jupyter_core.tests
+packages = find:
 include_package_data = True
 python_requires = >=3.6
 install_requires =


### PR DESCRIPTION
Setuptools is not including `juptyer_core/*.py` files.

```
Traceback (most recent call last):
  File "/build/pytest-of-nixbld/pytest-0/test_argv00/a/jupyter", line 1, in <module>
    from jupyter_core import command; command.main()
ModuleNotFoundError: No module named 'jupyter_core'
```