### PR TITLE
Clean up CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
             python-version: "3.8"
     steps:
       - uses: actions/checkout@v2
-      - with: jupyterlab/maintainer-tools/.github/actions/base-action@v1
+      - uses: jupyterlab/maintainer-tools/.github/actions/base-action@v1
       - name: Install dependencies
         run: |
           pip install -e ".[test]"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,15 @@ name: Python package
 on:
   push:
   pull_request:
-    branches: ["master"]
+  schedule:
+    - cron: "0 8 * * *"
+
+concurrency:
+  group: >-
+    ${{ github.workflow }}-
+    ${{ github.ref_type }}-
+    ${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
 
 jobs:
   build:
@@ -15,42 +23,76 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.7, 3.8, 3.9, "3.10", pypy-3.7]
-        exclude:
-          # pywin32 not available
+        python-version: ["3.7", "3.10"]
+        include:
           - os: windows-latest
-            python-version: "3.10"
+            python-version: "3.9"
+          - os: ubuntu-latest
+            python-version: "pypy-3.8"
+          - os: macos-latest
+            python-version: "3.8"
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Get pip cache dir
-        id: pip-cache
-        run: |
-          echo "::set-output name=dir::$(pip cache dir)"
-      - name: pip cache
-        uses: actions/cache@v2
-        with:
-          path: ${{ steps.pip-cache.outputs.dir }}
-          key: |
-            ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('dev-requirements.txt', 'setup.cfg') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-${{ matrix.python-version }}-
-            ${{ runner.os }}-pip-
+      - with: jupyterlab/maintainer-tools/.github/actions/base-action@v1
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install --upgrade setuptools wheel
           pip install -r dev-requirements.txt .
       - name: Test with pytest
         run: |
-          pytest -vv jupyter_core --timeout 60 --cov jupyter_core --cov-report term-missing:skip-covered
-      - name: Check manifest
+          python -m pytest -vv jupyter_core --timeout 60 --cov jupyter_core --cov-report term-missing:skip-covered
+
+  test_miniumum_versions:
+    name: Test Minimum Versions
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v2
+      - name: Base Setup
+        uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+        with:
+          python_version: "3.7"
+      - name: Install miniumum versions
+        uses: jupyterlab/maintainer-tools/.github/actions/install-minimums@v1
+      - name: Run the unit tests
+        run: pytest -vv -W default traitlets || pytest -vv -W default traitlets --lf
+
+  test_prereleases:
+    name: Test Prereleases
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Base Setup
+        uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+      - name: Install the Python dependencies
         run: |
-          pip install check-manifest
-          check-manifest -v
+          pip install --upgrade --upgrade-strategy eager --pre -e ".[test]"
+      - name: List installed packages
+        run: |
+          pip freeze
+          pip check
+      - name: Run the tests
+        run: |
+          pytest -vv traitlets || pytest -vv traitlets --lf
+
+  make_sdist:
+    name: Make SDist
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v2
+      - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+      - uses: jupyterlab/maintainer-tools/.github/actions/make-sdist@v1
+
+  test_sdist:
+    runs-on: ubuntu-latest
+    needs: [make_sdist]
+    name: Install from SDist and Test
+    timeout-minutes: 20
+    steps:
+      - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+      - uses: jupyterlab/maintainer-tools/.github/actions/test-sdist@v1
 
   pre-commit:
     name: pre-commit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
             python-version: "3.8"
     steps:
       - uses: actions/checkout@v2
-      - uses: jupyterlab/maintainer-tools/.github/actions/base-action@v1
+      - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
       - name: Install dependencies
         run: |
           pip install -e ".[test]"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
       - with: jupyterlab/maintainer-tools/.github/actions/base-action@v1
       - name: Install dependencies
         run: |
-          pip install -r dev-requirements.txt .
+          pip install -e ".[test]"
       - name: Test with pytest
         run: |
           python -m pytest -vv jupyter_core --timeout 60 --cov jupyter_core --cov-report term-missing:skip-covered

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
           pip install -e ".[test]"
       - name: Test with pytest
         run: |
-          python -m pytest -vv jupyter_core --timeout 60 --cov jupyter_core --cov-report term-missing:skip-covered
+          python -m pytest -vv --timeout 60 --cov jupyter_core --cov-report term-missing:skip-covered
 
   test_miniumum_versions:
     name: Test Minimum Versions
@@ -54,7 +54,7 @@ jobs:
       - name: Install miniumum versions
         uses: jupyterlab/maintainer-tools/.github/actions/install-minimums@v1
       - name: Run the unit tests
-        run: pytest -vv -W default traitlets || pytest -vv -W default traitlets --lf
+        run: pytest -vv -W default || pytest -vv -W default --lf
 
   test_prereleases:
     name: Test Prereleases
@@ -74,7 +74,7 @@ jobs:
           pip check
       - name: Run the tests
         run: |
-          pytest -vv traitlets || pytest -vv traitlets --lf
+          pytest -vv || pytest -vv --lf
 
   make_sdist:
     name: Make SDist

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -72,6 +72,12 @@ repos:
               scripts/jupyter
             )$
 
+  - repo: https://github.com/mgedmin/check-manifest
+    rev: '0.48'
+    hooks:
+    - id: check-manifest
+      stages: [manual]
+
   - repo: https://github.com/sirosen/check-jsonschema
     rev: 0.14.2
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -73,10 +73,10 @@ repos:
             )$
 
   - repo: https://github.com/mgedmin/check-manifest
-    rev: '0.48'
+    rev: "0.48"
     hooks:
-    - id: check-manifest
-      stages: [manual]
+      - id: check-manifest
+        stages: [manual]
 
   - repo: https://github.com/sirosen/check-jsonschema
     rev: 0.14.2

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,6 @@
 include COPYING.md
 include CONTRIBUTING.md
 include README.md
-include dev-requirements.txt
 include jupyter_core/py.typed
 
 exclude .pre-commit-config.yaml

--- a/README.md
+++ b/README.md
@@ -16,8 +16,7 @@ Now create an [editable install](https://pip.pypa.io/en/stable/reference/pip_ins
 and download the dependencies of code and test suite by executing:
 
     cd /my/projects/jupyter_core/
-    pip install -e .
-    pip install -r dev-requirements.txt
+    pip install -e ".[test]"
     py.test
 
 The last command runs the test suite to verify the setup. During development, you can pass filenames to `py.test`, and it will execute only those tests.

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,0 @@
-ipykernel
-pre-commit
-pytest
-pytest-cov
-pytest-timeout

--- a/jupyter_core/tests/test_command.py
+++ b/jupyter_core/tests/test_command.py
@@ -56,7 +56,7 @@ def write_executable(path, source):
             import pkg_resources
 
             w = pkg_resources.resource_string("setuptools", "cli-32.exe")
-        except (ImportError, FileNotFoundError):
+        except (ImportError, FileNotFoundError, SystemError):
             pytest.skip("Need pkg_resources/setuptools to make scripts executable on Windows")
         exe.write(w, "wb")
         exe.chmod(0o700)

--- a/jupyter_core/tests/test_paths.py
+++ b/jupyter_core/tests/test_paths.py
@@ -417,7 +417,10 @@ def test_secure_write_win32():
     def fetch_win32_permissions(filename):
         """Extracts file permissions on windows using icacls"""
         role_permissions = {}
-        for index, line in enumerate(os.popen("icacls %s" % filename).read().splitlines()):
+        proc = os.popen("icacls %s" % filename)
+        lines = proc.read().splitlines()
+        proc.close()
+        for index, line in enumerate(lines):
             if index == 0:
                 line = line.split(filename)[-1].strip().lower()
             match = re.match(r"\s*([^:]+):\(([^\)]*)\)", line)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,5 +36,5 @@ testpaths = [
 ]
 filterwarnings= [
   # Fail on warnings
-  "error"
+  "error",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,3 +27,14 @@ module = [
     "entrypoints"
 ]
 ignore_missing_imports = true
+
+
+[tool.pytest.ini_options]
+addopts = "-raXs --durations 10 --color=yes --doctest-modules --ignore-glob=jupyter_core/tests/dotipython*"
+testpaths = [
+    "jupyter_core/tests/"
+]
+filterwarnings= [
+  # Fail on warnings
+  "error"
+]

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,6 +38,12 @@ console_scripts =
     jupyter-migrate      = jupyter_core.migrate:main
     jupyter-troubleshoot = jupyter_core.troubleshoot:main
 
+[options.extras_require]
+test =
+    pytest
+    pytest-cov
+    pytest-timeout
+
 [flake8]
 ignore = E501, W503, E402
 builtins = c, get_config

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,6 +40,8 @@ console_scripts =
 
 [options.extras_require]
 test =
+    ipykernel
+    pre-commit
     pytest
     pytest-cov
     pytest-timeout


### PR DESCRIPTION
- Improve test matrix
- Add concurrency limit handling for GitHub Actions
- Add cron job to run tests daily
- Use base-setup from maintainer-tools to handle python version, caching, and pip upgrades
- Add tests for minimum versions, pre-releases, and sdist testing
- Update pytest config and handle warnings