### PR TITLE
Use hatch backend

### DIFF
--- a/jupyter_core/version.py
+++ b/jupyter_core/version.py
@@ -6,6 +6,7 @@ from collections import namedtuple
 VersionInfo = namedtuple("VersionInfo", ["major", "minor", "micro", "releaselevel", "serial"])
 
 version_info = VersionInfo(4, 10, 0, "final", 0)
+__version__ = "4.10.0"
 
 _specifier_ = {"alpha": "a", "beta": "b", "candidate": "rc", "final": "", "dev": "dev"}
 
@@ -16,4 +17,4 @@ elif version_info.releaselevel == "dev":
 else:
     _suffix_ = f"{_specifier_[version_info.releaselevel]}{version_info.serial}"
 
-__version__ = f"{version_info.major}.{version_info.minor}.{version_info.micro}{_suffix_}"
+assert __version__ == f"{version_info.major}.{version_info.minor}.{version_info.micro}{_suffix_}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["flit_core >=3.2,<4"]
-build-backend = "flit_core.buildapi"
+requires = ["hatchling>=0.25"]
+build-backend = "hatchling.build"
 
 [project]
 name = "jupyter_core"
@@ -50,6 +50,9 @@ test = [
 jupyter = "jupyter_core.command:main"
 jupyter-migrate = "jupyter_core.migrate:main"
 jupyter-troubleshoot = "jupyter_core.troubleshoot:main"
+
+[tool.hatch.version]
+path = "jupyter_core/version.py"
 
 [tool.mypy]
 check_untyped_defs = true


### PR DESCRIPTION
Hatch is newly added pypa backend with more flexibility, and helps avoid https://github.com/pypa/pip/issues/11110, which is breaking builds.