### PR TITLE
is_hidden: Use normalized paths

### DIFF
--- a/jupyter_core/paths.py
+++ b/jupyter_core/paths.py
@@ -384,7 +384,10 @@ def is_hidden(abs_path, abs_root=""):
         The absolute path of the root directory in which hidden directories
         should be checked for.
     """
-    if os.path.normpath(abs_path) == os.path.normpath(abs_root):
+    abs_path = os.path.normpath(abs_path)
+    abs_root = os.path.normpath(abs_root)
+
+    if abs_path == abs_root:
         return False
 
     if is_file_hidden(abs_path):


### PR DESCRIPTION
The current `is_hidden` implementation considers the path `path/to/my/./file.txt` to be hidden, while it's not. This PR fixes it by normalizing the paths prior to compute the `is_hidden` logic.

Similar fix in `jupyter_server` https://github.com/jupyter-server/jupyter_server/pull/886