### PR TITLE
Try to detect if we are in a virtual environment and change path precedence accordingly

### DIFF
--- a/jupyter_core/command.py
+++ b/jupyter_core/command.py
@@ -231,13 +231,13 @@ def main():
                 if args.debug:
                     env = os.environ
 
-                    if paths.envset("JUPYTER_PREFER_ENV_PATH"):
+                    if paths.prefer_environment_over_user():
                         print(
-                            "JUPYTER_PREFER_ENV_PATH is set, making the environment-level path preferred over the user-level path for data and config"
+                            "JUPYTER_PREFER_ENV_PATH is set to a true value or we detected a virtual environment, making the environment-level path preferred over the user-level path for data and config"
                         )
                     else:
                         print(
-                            "JUPYTER_PREFER_ENV_PATH is not set, making the user-level path preferred over the environment-level path for data and config"
+                            "JUPYTER_PREFER_ENV_PATH is not set and we did not detect a virtual environment, or JUPYTER_PREFER_ENV_PATH is set to a false value, making the user-level path preferred over the environment-level path for data and config"
                         )
 
                     # config path list

--- a/jupyter_core/command.py
+++ b/jupyter_core/command.py
@@ -233,11 +233,11 @@ def main():
 
                     if paths.prefer_environment_over_user():
                         print(
-                            "JUPYTER_PREFER_ENV_PATH is set to a true value or we detected a virtual environment, making the environment-level path preferred over the user-level path for data and config"
+                            "JUPYTER_PREFER_ENV_PATH is set to a true value, or JUPYTER_PREFER_ENV_PATH is not set and we detected a virtual environment, making the environment-level path preferred over the user-level path for data and config"
                         )
                     else:
                         print(
-                            "JUPYTER_PREFER_ENV_PATH is not set and we did not detect a virtual environment, or JUPYTER_PREFER_ENV_PATH is set to a false value, making the user-level path preferred over the environment-level path for data and config"
+                            "JUPYTER_PREFER_ENV_PATH is set to a false value, or JUPYTER_PREFER_ENV_PATH is not set and we did not detect a virtual environment, making the user-level path preferred over the environment-level path for data and config"
                         )
 
                     # config path list

--- a/jupyter_core/paths.py
+++ b/jupyter_core/paths.py
@@ -275,7 +275,7 @@ def jupyter_config_path():
 
     env = [p for p in ENV_CONFIG_PATH if p not in SYSTEM_CONFIG_PATH]
 
-    if prefer_environment_over_user:
+    if prefer_environment_over_user():
         paths.extend(env)
         paths.extend(user)
     else:

--- a/jupyter_core/paths.py
+++ b/jupyter_core/paths.py
@@ -51,10 +51,11 @@ def get_home_dir():
 
 _dtemps: dict = {}
 
+
 def prefer_environment_over_user():
     """Determine if environment-level paths should take precedence over user-level paths."""
     # If JUPYTER_PREFER_ENV_PATH is defined, that signals user intent, so return its value
-    if 'JUPYTER_PREFER_ENV_PATH' in os.environ:
+    if "JUPYTER_PREFER_ENV_PATH" in os.environ:
         return envset("JUPYTER_PREFER_ENV_PATH")
 
     # If we are in a Python virtualenv, default to True (see https://docs.python.org/3/library/venv.html#venv-def)
@@ -62,7 +63,7 @@ def prefer_environment_over_user():
         return True
 
     # If sys.prefix indicates Python comes from a conda/mamba environment, default to True
-    if 'CONDA_PREFIX' in os.environ and sys.prefix.startswith(os.environ['CONDA_PREFIX']):
+    if "CONDA_PREFIX" in os.environ and sys.prefix.startswith(os.environ["CONDA_PREFIX"]):
         return True
 
     return False

--- a/jupyter_core/paths.py
+++ b/jupyter_core/paths.py
@@ -26,13 +26,18 @@ pjoin = os.path.join
 UF_HIDDEN = getattr(stat, "UF_HIDDEN", 32768)
 
 
-def envset(name):
-    """Return True if the given environment variable is set
+def envset(name, default=False):
+    """Return the boolean value of a given environment variable.
 
     An environment variable is considered set if it is assigned to a value
     other than 'no', 'n', 'false', 'off', '0', or '0.0' (case insensitive)
+
+    If the environment variable is not defined, the default value is returned.
     """
-    return os.environ.get(name, "no").lower() not in ["no", "n", "false", "off", "0", "0.0"]
+    if name not in os.environ:
+        return default
+
+    return os.environ[name].lower() not in ["no", "n", "false", "off", "0", "0.0"]
 
 
 def get_home_dir():
@@ -45,6 +50,22 @@ def get_home_dir():
 
 
 _dtemps: dict = {}
+
+def prefer_environment_over_user():
+    """Determine if environment-level paths should take precedence over user-level paths."""
+    # If JUPYTER_PREFER_ENV_PATH is defined, that signals user intent, so return its value
+    if 'JUPYTER_PREFER_ENV_PATH' in os.environ:
+        return envset("JUPYTER_PREFER_ENV_PATH")
+
+    # If we are in a Python virtualenv, default to True (see https://docs.python.org/3/library/venv.html#venv-def)
+    if sys.prefix != sys.base_prefix:
+        return True
+
+    # If sys.prefix indicates Python comes from a conda/mamba environment, default to True
+    if 'CONDA_PREFIX' in os.environ and sys.prefix.startswith(os.environ['CONDA_PREFIX']):
+        return True
+
+    return False
 
 
 def _mkdtemp_once(name):
@@ -184,7 +205,7 @@ def jupyter_path(*subdirs):
 
     env = [p for p in ENV_JUPYTER_PATH if p not in SYSTEM_JUPYTER_PATH]
 
-    if envset("JUPYTER_PREFER_ENV_PATH"):
+    if prefer_environment_over_user():
         paths.extend(env)
         paths.extend(user)
     else:
@@ -253,7 +274,7 @@ def jupyter_config_path():
 
     env = [p for p in ENV_CONFIG_PATH if p not in SYSTEM_CONFIG_PATH]
 
-    if envset("JUPYTER_PREFER_ENV_PATH"):
+    if prefer_environment_over_user:
         paths.extend(env)
         paths.extend(user)
     else:

--- a/jupyter_core/tests/test_command.py
+++ b/jupyter_core/tests/test_command.py
@@ -23,7 +23,6 @@ resetenv = patch.dict(os.environ)
 
 def setup_module():
     resetenv.start()
-    os.environ.pop("JUPYTER_PREFER_ENV_PATH", None)
 
 
 def teardown_module():

--- a/jupyter_core/tests/test_paths.py
+++ b/jupyter_core/tests/test_paths.py
@@ -344,8 +344,11 @@ def test_prefer_environment_over_user():
 
     # Test default if environment variable is not set, and try to determine if we are in a virtual environment
     os.environ.pop("JUPYTER_PREFER_ENV_PATH", None)
-    in_venv = sys.prefix != sys.base_prefix or ("CONDA_PREFIX" in os.environ and sys.prefix.startswith(os.environ["CONDA_PREFIX"]))
+    in_venv = sys.prefix != sys.base_prefix or (
+        "CONDA_PREFIX" in os.environ and sys.prefix.startswith(os.environ["CONDA_PREFIX"])
+    )
     assert prefer_environment_over_user() is in_venv
+
 
 def test_is_hidden():
     with tempfile.TemporaryDirectory() as root:

--- a/jupyter_core/tests/test_paths.py
+++ b/jupyter_core/tests/test_paths.py
@@ -67,7 +67,9 @@ resetenv = patch.dict(os.environ)
 
 def setup_module():
     resetenv.start()
-    os.environ.pop("JUPYTER_PREFER_ENV_PATH", None)
+    # For these tests, default to preferring the user-level over environment-level paths
+    # Tests can override this preference using the prefer_env decorator/context manager
+    os.environ["JUPYTER_PREFER_ENV_PATH"] = "no"
 
 
 def teardown_module():

--- a/jupyter_core/tests/test_paths.py
+++ b/jupyter_core/tests/test_paths.py
@@ -89,7 +89,10 @@ def test_envset():
             assert paths.envset(f"FOO_{v}")
         for v in false_values:
             assert not paths.envset(f"FOO_{v}")
-        assert not paths.envset("THIS_VARIABLE_SHOULD_NOT_BE_SET")
+        # Test default value is False
+        assert paths.envset("THIS_VARIABLE_SHOULD_NOT_BE_SET") is False
+        # Test envset returns the given default if supplied
+        assert paths.envset("THIS_VARIABLE_SHOULD_NOT_BE_SET", None) is None
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")


### PR DESCRIPTION
We make the assumption that if we are in a virtual environment, we should prioritize the environment-level sys.prefix over the user-level paths. The user can opt out of this behavior by setting JUPYTER_PREFER_ENV_PATH, which takes precedence over our autodetection.

Fixes #283
