### PR TITLE
Clear the test environment before each function run

### DIFF
--- a/jupyter_core/tests/test_command.py
+++ b/jupyter_core/tests/test_command.py
@@ -21,11 +21,20 @@ from jupyter_core.paths import (
 resetenv = patch.dict(os.environ)
 
 
-def setup_module():
+def setup_function():
     resetenv.start()
+    for var in [
+        "JUPYTER_CONFIG_DIR",
+        "JUPYTER_CONFIG_PATH",
+        "JUPYTER_DATA_DIR",
+        "JUPYTER_NO_CONFIG",
+        "JUPYTER_PATH",
+        "JUPYTER_PLATFORM_DIRS",
+        "JUPYTER_RUNTIME_DIR",
+    ]:
+        os.environ.pop(var, None)
 
-
-def teardown_module():
+def teardown_function():
     resetenv.stop()
 
 

--- a/jupyter_core/tests/test_command.py
+++ b/jupyter_core/tests/test_command.py
@@ -34,6 +34,7 @@ def setup_function():
     ]:
         os.environ.pop(var, None)
 
+
 def teardown_function():
     resetenv.stop()
 


### PR DESCRIPTION
See #231

This attempts to make our test environment more reproducible by setting the environment variables to a known state before each function run.