### PR TITLE
Set up shell command-line tab-completion for jupyter and subcommands

### DIFF
--- a/examples/jupyter-completion.bash
+++ b/examples/jupyter-completion.bash
@@ -1,4 +1,10 @@
 # load with: . jupyter-completion.bash
+#
+# NOTE: with traitlets>=5.8, jupyter and its subcommands now directly support
+# shell command-line tab-completion using argcomplete, which has more complete
+# support than this script. Simply install argcomplete and activate global
+# completion by following the relevant instructions in:
+# https://kislyuk.github.io/argcomplete/#activating-global-completion
 
 if [[ -n ${ZSH_VERSION-} ]]; then
     autoload -Uz bashcompinit && bashcompinit

--- a/jupyter_core/command.py
+++ b/jupyter_core/command.py
@@ -189,7 +189,7 @@ def _path_with_self():
 
 def _evaluate_argcomplete(parser: JupyterParser) -> List[str]:
     """If argcomplete is enabled, trigger autocomplete or return current words
-    
+
     If the first word looks like a subcommand, return the current command
     that is attempting to be completed so that the subcommand can evaluate it;
     otherwise auto-complete using the main parser.

--- a/jupyter_core/command.py
+++ b/jupyter_core/command.py
@@ -1,3 +1,4 @@
+# PYTHON_ARGCOMPLETE_OK
 """The root `jupyter` command.
 
 This does nothing other than dispatch to subcommands or output path info.
@@ -37,6 +38,15 @@ class JupyterParser(argparse.ArgumentParser):
         """Ignore epilog set in Parser.__init__"""
         pass
 
+    def argcomplete(self):
+        """Trigger auto-completion, if enabled"""
+        try:
+            import argcomplete  # type: ignore[import]
+
+            argcomplete.autocomplete(self)
+        except ImportError:
+            pass
+
 
 def jupyter_parser() -> JupyterParser:
     """Create a jupyter parser object."""
@@ -48,7 +58,11 @@ def jupyter_parser() -> JupyterParser:
     group.add_argument(
         "--version", action="store_true", help="show the versions of core jupyter packages and exit"
     )
-    group.add_argument("subcommand", type=str, nargs="?", help="the subcommand to launch")
+    subcommand_action = group.add_argument(
+        "subcommand", type=str, nargs="?", help="the subcommand to launch"
+    )
+    # For argcomplete, supply all known subcommands
+    subcommand_action.completer = lambda *args, **kwargs: list_subcommands()  # type: ignore[attr-defined]
 
     group.add_argument("--config-dir", action="store_true", help="show Jupyter config dir")
     group.add_argument("--data-dir", action="store_true", help="show Jupyter data dir")
@@ -173,13 +187,49 @@ def _path_with_self():
     return path_list
 
 
+def _evaluate_argcomplete(parser: JupyterParser) -> List[str]:
+    """If argcomplete is enabled, trigger autocomplete or return current words
+    
+    If the first word looks like a subcommand, return the current command
+    that is attempting to be completed so that the subcommand can evaluate it;
+    otherwise auto-complete using the main parser.
+    """
+    try:
+        # traitlets >= 5.8 provides some argcomplete support,
+        # use helper methods to jump to argcomplete
+        from traitlets.config.argcomplete_config import (
+            get_argcomplete_cwords,
+            increment_argcomplete_index,
+        )
+
+        cwords = get_argcomplete_cwords()
+        if cwords and len(cwords) > 1 and not cwords[1].startswith("-"):
+            # If first completion word looks like a subcommand,
+            # increment word from which to start handling arguments
+            increment_argcomplete_index()
+            return cwords
+        else:
+            # Otherwise no subcommand, directly autocomplete and exit
+            parser.argcomplete()
+    except ImportError:
+        # traitlets >= 5.8 not available, just try to complete this without
+        # worrying about subcommands
+        parser.argcomplete()
+    raise AssertionError("Control flow should not reach end of autocomplete()")
+
+
 def main() -> None:
     """The command entry point."""
     parser = jupyter_parser()
-    if len(sys.argv) > 1 and not sys.argv[1].startswith("-"):
+    argv = sys.argv
+    subcommand = None
+    if "_ARGCOMPLETE" in os.environ:
+        argv = _evaluate_argcomplete(parser)
+        subcommand = argv[1]
+    elif len(argv) > 1 and not argv[1].startswith("-"):
         # Don't parse if a subcommand is given
         # Avoids argparse gobbling up args passed to subcommand, such as `-h`.
-        subcommand = sys.argv[1]
+        subcommand = argv[1]
     else:
         args, opts = parser.parse_known_args()
         subcommand = args.subcommand
@@ -343,7 +393,7 @@ def main() -> None:
         sys.exit(str(e))
 
     try:
-        _execvp(command, [command] + sys.argv[2:])
+        _execvp(command, [command] + argv[2:])
     except OSError as e:
         sys.exit(f"Error executing Jupyter command {subcommand!r}: {e}")
 

--- a/jupyter_core/migrate.py
+++ b/jupyter_core/migrate.py
@@ -1,3 +1,4 @@
+# PYTHON_ARGCOMPLETE_OK
 """Migrating IPython < 4.0 to Jupyter
 
 This *copies* configuration and resources to their new locations in Jupyter

--- a/jupyter_core/troubleshoot.py
+++ b/jupyter_core/troubleshoot.py
@@ -51,6 +51,11 @@ def main() -> None:
     """
     # pylint: disable=superfluous-parens
     # args = get_args()
+    if "_ARGCOMPLETE" in os.environ:
+        # No arguments to complete, the script can be slow to run to completion,
+        # so in case someone tries to complete jupyter troubleshoot just exit early
+        return
+
     environment_data = get_data()
 
     print("$PATH:")

--- a/scripts/jupyter-migrate
+++ b/scripts/jupyter-migrate
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# PYTHON_ARGCOMPLETE_OK
 """Migrate Jupyter config from IPython < 4.0"""
 
 from jupyter_core.migrate import main


### PR DESCRIPTION
Set up shell command-line tab-completion using `argcomplete` and ipython/traitlets#811. Completion requires `argcomplete` to be activated and `traitlets>=5.8`. Behavior is only changed when `$_ARGCOMPLETE` is set, so there should be no difference in behavior otherwise.

For subcommand handling, this will use `list_subcommands()` to try to complete the first argument if it doesn't start with a "-", and when a subcommand is detected, `argcomplete` will increment the start of the command-line handling past the subcommand and drop into the relevant `traitlets.Application`'s argcomplete handling. All of the major subcommands like `jupyter lab` directly use `traitlets.Application.launch_instance` so this works pretty seamlessly. However, completing commands that start with the hyphenated commands, e.g. `jupyter-lab`, would still require the addition of the `PYTHON_ARGCOMPLETE_OK` marker in the respective projects' main scripts. Note that argcomplete supports following setuptools `console_scripts` to the corresponding main script to look for the `PYTHON_ARGCOMPLETE_OK` marker.

Example:

```bash
$ jupyter <TAB>
--config-dir      --runtime-dir     kernel            nbconvert         serverextension
--data-dir        --version         kernelspec        nbextension       troubleshoot
--debug           -h                lab               notebook          trust
--help            bundlerextension  labextension      qtconsole
--json            console           labhub            run
--paths           dejavu            migrate           server
$ jupyter lab <TAB>  # shows flags, subcommands, and files
--Application.               --dev-mode                   .git/
--ConnectionFileMixin.       --expose-app-in-browser      .github/
--ContentsManager.           --gateway-url                .gitignore
--FileContentsManager.       --generate-config            .mypy_cache/
--FileManagerMixin.          --help                       .pre-commit-config.yaml
--GatewayClient.             --ip                         .readthedocs.yaml
--GatewayKernelManager.      --keyfile                    .ruff_cache/
--GatewayKernelSpecManager.  --log-level                  CHANGELOG.md
--JupyterApp.                --no-browser                 CONTRIBUTING.md
--KernelManager.             --no-mathjax                 COPYING.md
--KernelSpecManager.         --no-script                  README.md
--LabApp.                    --notebook-dir               __pycache__/
--MappingKernelManager.      --port                       build
--MultiKernelManager.        --port-retries               clean
--NotebookApp.               --pylab                      codecov.yml
--NotebookNotary.            --script                     docs/
--Session.                   --show-config                examples/
--TerminalManager.           --show-config-json           jupyter.py
--allow-root                 --sock                       jupyter_core/
--app-dir                    --sock-mode                  path
--autoreload                 --transport                  paths
--browser                    --watch                      pyproject.toml
--certfile                   --y                          scripts/
--client-ca                  -h                           workspace
--config                     -y                           workspaces
--core-mode                  .flake8
--debug                      .git-blame-ignore-revs
$ jupyter lab --Kernel<TAB>
--KernelManager.      --KernelSpecManager.
$ jupyter lab --KernelManager.<TAB>
--KernelManager.autorestart         --KernelManager.kernel_cmd
--KernelManager.connection_file     --KernelManager.shell_port
--KernelManager.control_port        --KernelManager.shutdown_wait_time
--KernelManager.hb_port             --KernelManager.stdin_port
--KernelManager.iopub_port          --KernelManager.transport
--KernelManager.ip
$ jupyter lab --KernelManager.transport <TAB>
ipc  tcp

```

