### PR TITLE
put_script_path first

### DIFF
--- a/jupyter_core/command.py
+++ b/jupyter_core/command.py
@@ -203,7 +203,9 @@ def _evaluate_argcomplete(parser: JupyterParser) -> List[str]:
         # traitlets >= 5.8 provides some argcomplete support,
         # use helper methods to jump to argcomplete
         from traitlets.config.argcomplete_config import (
-            get_argcomplete_cwords, increment_argcomplete_index)
+            get_argcomplete_cwords,
+            increment_argcomplete_index,
+        )
 
         cwords = get_argcomplete_cwords()
         if cwords and len(cwords) > 1 and not cwords[1].startswith("-"):

--- a/jupyter_core/command.py
+++ b/jupyter_core/command.py
@@ -173,7 +173,10 @@ def _path_with_self():
         # The Python environment does not specify a "scripts" location
         pass
     else:
-        path_list.append(bindir)
+        if os.environ.get("JUPYTER_PREFER_ENV_PATH", False):
+            path_list.insert(0, bindir)
+        else:
+            path_list.append(bindir)
 
     scripts = [sys.argv[0]]
     if os.path.islink(scripts[0]):
@@ -200,9 +203,7 @@ def _evaluate_argcomplete(parser: JupyterParser) -> List[str]:
         # traitlets >= 5.8 provides some argcomplete support,
         # use helper methods to jump to argcomplete
         from traitlets.config.argcomplete_config import (
-            get_argcomplete_cwords,
-            increment_argcomplete_index,
-        )
+            get_argcomplete_cwords, increment_argcomplete_index)
 
         cwords = get_argcomplete_cwords()
         if cwords and len(cwords) > 1 and not cwords[1].startswith("-"):


### PR DESCRIPTION
Not actually a suggested PR -- I suspect that there's other work here. 

Opening this as a fix for the issue https://github.com/jupyter/jupyter_core/issues/339

It might be the case that I'm misunderstanding the `JUPYTER_PREFER_ENV_PATH`. It is a flag that gets set when in virtualenvs, for the other `paths.py` part of the work. This seems unrelated to "OS PATH" style stuff. However, it is the case that I want the script directory (the one found via `sysconfig.get_path("scripts")`) to be the preferred path for subcommand execution. 

By adding these lines to my jupyter-core, my issues went away. I was now no longer getting shorted out by the wrong scripts / shims from pyenv. (I think it's a separate issue that the shim was resolving incorrectly to nothing)