### PR TITLE
go back to using nest_asyncio for run_sync utility

### DIFF
--- a/jupyter_core/utils/patched_nest_asyncio.py
+++ b/jupyter_core/utils/patched_nest_asyncio.py
@@ -1,0 +1,54 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+# Note: copied from https://github.com/ipyflow/ipyflow/blob/8e4bc5cb8d4231b9b69f4f9dce867b8101164ac5/core/ipyflow/kernel/patched_nest_asyncio.py
+import asyncio
+import sys
+
+
+def apply(loop=None):
+    import nest_asyncio
+
+    # ref: https://github.com/erdewit/nest_asyncio/issues/14
+    nest_asyncio._patch_task = _patched_patch_task
+
+    # ref: https://github.com/erdewit/nest_asyncio
+    nest_asyncio.apply(loop=loop)
+
+
+def _patched_patch_task():
+    """Patch the Task's step and enter/leave methods to make it reentrant."""
+
+    def step(task, exc=None):
+        curr_task = curr_tasks.get(task._loop)
+        try:
+            step_orig(task, exc)
+        finally:
+            if curr_task is None:
+                curr_tasks.pop(task._loop, None)
+            else:
+                curr_tasks[task._loop] = curr_task
+
+    Task = asyncio.Task
+    if sys.version_info >= (3, 7, 0):
+
+        def enter_task(loop, task):
+            curr_tasks[loop] = task
+
+        def leave_task(loop, task):
+            curr_tasks.pop(loop, None)
+
+        asyncio.tasks._enter_task = enter_task
+        asyncio.tasks._leave_task = leave_task
+        curr_tasks = asyncio.tasks._current_tasks
+    else:
+        curr_tasks = Task._current_tasks
+    try:
+        step_orig = Task._Task__step
+        Task._Task__step = step
+    except AttributeError:
+        try:
+            step_orig = Task.__step
+            Task.__step = step
+        except AttributeError:
+            step_orig = Task._step
+            Task._step = step

--- a/jupyter_core/utils/patched_nest_asyncio.py
+++ b/jupyter_core/utils/patched_nest_asyncio.py
@@ -29,6 +29,8 @@ def _patched_patch_task():
                 curr_tasks[task._loop] = curr_task
 
     Task = asyncio.Task
+    if hasattr(Task, '_nest_patched'):
+        return
     if sys.version_info >= (3, 7, 0):
 
         def enter_task(loop, task):
@@ -52,3 +54,4 @@ def _patched_patch_task():
         except AttributeError:
             step_orig = Task._step  # type: ignore
             Task._step = step  # type: ignore
+    Task._nest_patched = True  # type: ignore

--- a/jupyter_core/utils/patched_nest_asyncio.py
+++ b/jupyter_core/utils/patched_nest_asyncio.py
@@ -39,16 +39,16 @@ def _patched_patch_task():
 
         asyncio.tasks._enter_task = enter_task
         asyncio.tasks._leave_task = leave_task
-        curr_tasks = asyncio.tasks._current_tasks  # noqa
+        curr_tasks = asyncio.tasks._current_tasks  # type: ignore
     else:
-        curr_tasks = Task._current_tasks  # noqa
+        curr_tasks = Task._current_tasks  # type: ignore
     try:
-        step_orig = Task._Task__step  # noqa
-        Task._Task__step = step  # noqa
+        step_orig = Task._Task__step  # type: ignore
+        Task._Task__step = step  # type: ignore
     except AttributeError:
         try:
-            step_orig = Task.__step  # noqa
-            Task.__step = step  # noqa
+            step_orig = Task.__step  # type: ignore
+            Task.__step = step  # type: ignore
         except AttributeError:
-            step_orig = Task._step  # noqa
-            Task._step = step  # noqa
+            step_orig = Task._step  # type: ignore
+            Task._step = step  # type: ignore

--- a/jupyter_core/utils/patched_nest_asyncio.py
+++ b/jupyter_core/utils/patched_nest_asyncio.py
@@ -39,16 +39,16 @@ def _patched_patch_task():
 
         asyncio.tasks._enter_task = enter_task
         asyncio.tasks._leave_task = leave_task
-        curr_tasks = asyncio.tasks._current_tasks
+        curr_tasks = asyncio.tasks._current_tasks  # noqa
     else:
-        curr_tasks = Task._current_tasks
+        curr_tasks = Task._current_tasks  # noqa
     try:
-        step_orig = Task._Task__step
-        Task._Task__step = step
+        step_orig = Task._Task__step  # noqa
+        Task._Task__step = step  # noqa
     except AttributeError:
         try:
-            step_orig = Task.__step
-            Task.__step = step
+            step_orig = Task.__step  # noqa
+            Task.__step = step  # noqa
         except AttributeError:
-            step_orig = Task._step
-            Task._step = step
+            step_orig = Task._step  # noqa
+            Task._step = step  # noqa

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ classifiers = [
 ]
 requires-python = ">=3.8"
 dependencies = [
+  "nest_asyncio",
   "platformdirs>=2.5",
   "traitlets>=5.3",
   "pywin32>=300 ; sys_platform == 'win32' and platform_python_implementation != 'PyPy'"


### PR DESCRIPTION
This PR appears to fix the issue described in https://github.com/jupyter/notebook/issues/6721, whereby users sporadically encounter `zmq message arrived on closed channel` errors in the tornado loop. It reverts the threaded implementation of `jupyter_core.utils.run_sync` and replaces it with the original one based on `nest_asyncio`.

Actually it uses a patched version of `nest_asyncio` from [here](https://github.com/ipyflow/ipyflow/blob/8e4bc5cb8d4231b9b69f4f9dce867b8101164ac5/core/ipyflow/kernel/patched_nest_asyncio.py), due to portability issues with the original version.

Unfortunately I don't fully understand why reverting the threaded implementation of `run_sync` is needed to eliminate these errors, but some users suggest it could have something to do with tornado coroutines not playing nicely when run across different threads: https://github.com/tornadoweb/tornado/issues/2871#issuecomment-638577266

Test plan: did an editable install locally and verified everything works well, and that all the zmq errors I encountered before are gone.