### PR TITLE
Better handling of config migration

### DIFF
--- a/jupyter_core/application.py
+++ b/jupyter_core/application.py
@@ -170,7 +170,7 @@ class JupyterApp(Application):
         """Migrate config/data from IPython 3"""
         try:  # let's see if we can open the marker file
             # for reading and updating (writing)
-            f_marker = open(os.path.join(self.config_dir, "migrated"), 'r+')
+            f_marker = open(os.path.join(self.config_dir, "migrated"), 'r+')  # noqa
         except PermissionError:  # not readable and/or writable
             return  # so let's give up migration in such an environment
         except FileNotFoundError:  # cannot find the marker file

--- a/jupyter_core/application.py
+++ b/jupyter_core/application.py
@@ -168,17 +168,17 @@ class JupyterApp(Application):
 
     def migrate_config(self):
         """Migrate config/data from IPython 3"""
-        try:# let's see if we can open the marker file
+        try:  # let's see if we can open the marker file
             # for reading and updating (writing)
             f_marker = open(os.path.join(self.config_dir, "migrated"), 'r+')
         except PermissionError:  # not readable and/or writable
             return  # so let' give up migration in such an environment
-        except FileNotFoundError: # cannot find the marker file
-            pass    # that means we have not migrated yet, so continue
-        else: # if we got here without raising anything,
+        except FileNotFoundError:  # cannot find the marker file
+            pass  # that means we have not migrated yet, so continue
+        else:  # if we got here without raising anything,
             # that means the file exists
             f_marker.close()
-            return      # so we must have already migrated -> bail out
+            return  # so we must have already migrated -> bail out
 
         from .migrate import get_ipython_dir, migrate
 

--- a/jupyter_core/application.py
+++ b/jupyter_core/application.py
@@ -168,9 +168,17 @@ class JupyterApp(Application):
 
     def migrate_config(self):
         """Migrate config/data from IPython 3"""
-        if os.path.exists(os.path.join(self.config_dir, "migrated")):
-            # already migrated
-            return
+        try:# let's see if we can open the marker file
+            # for reading and updating (writing)
+            f_marker = open(os.path.join(self.config_dir, "migrated"), 'r+')
+        except PermissionError:  # not readable and/or writable
+            return  # so let' give up migration in such an environment
+        except FileNotFoundError: # cannot find the marker file
+            pass    # that means we have not migrated yet, so continue
+        else: # if we got here without raising anything,
+            # that means the file exists
+            f_marker.close()
+            return      # so we must have already migrated -> bail out
 
         from .migrate import get_ipython_dir, migrate
 

--- a/jupyter_core/application.py
+++ b/jupyter_core/application.py
@@ -172,7 +172,7 @@ class JupyterApp(Application):
             # for reading and updating (writing)
             f_marker = open(os.path.join(self.config_dir, "migrated"), 'r+')
         except PermissionError:  # not readable and/or writable
-            return  # so let' give up migration in such an environment
+            return  # so let's give up migration in such an environment
         except FileNotFoundError:  # cannot find the marker file
             pass  # that means we have not migrated yet, so continue
         else:  # if we got here without raising anything,

--- a/jupyter_core/tests/test_migrate.py
+++ b/jupyter_core/tests/test_migrate.py
@@ -11,6 +11,7 @@ from unittest.mock import patch
 import pytest
 
 from jupyter_core import migrate as migrate_mod
+from jupyter_core.application import JupyterApp
 from jupyter_core.migrate import (
     migrate,
     migrate_config,
@@ -20,8 +21,6 @@ from jupyter_core.migrate import (
     migrate_static_custom,
 )
 from jupyter_core.utils import ensure_dir_exists
-
-from jupyter_core.application import JupyterApp
 
 pjoin = os.path.join
 here = os.path.dirname(__file__)
@@ -219,6 +218,7 @@ def test_migrate(env):
     assert os.path.exists(env["JUPYTER_CONFIG_DIR"])
     assert os.path.exists(env["JUPYTER_DATA_DIR"])
 
+
 def test_app_migrate(env):
     shutil.copytree(dotipython, env["IPYTHONDIR"])
     app = JupyterApp()
@@ -240,7 +240,7 @@ def test_app_migrate_skip_unwritable_marker(env):
     shutil.copytree(dotipython, env["IPYTHONDIR"])
     migrated_marker = pjoin(env["JUPYTER_CONFIG_DIR"], "migrated")
     touch(migrated_marker, "done")
-    os.chmod(migrated_marker, 0) # make it unworkable
+    os.chmod(migrated_marker, 0)  # make it unworkable
     app = JupyterApp()
     app.initialize([])
     assert os.listdir(env["JUPYTER_CONFIG_DIR"]) == ["migrated"]

--- a/jupyter_core/tests/test_migrate.py
+++ b/jupyter_core/tests/test_migrate.py
@@ -54,7 +54,7 @@ def env(request):
     def fin():
         """Cleanup test env"""
         env_patch.stop()
-        shutil.rmtree(td)
+        shutil.rmtree(td, ignore_errors=os.name=='nt')
 
     request.addfinalizer(fin)
 

--- a/jupyter_core/tests/test_migrate.py
+++ b/jupyter_core/tests/test_migrate.py
@@ -54,7 +54,7 @@ def env(request):
     def fin():
         """Cleanup test env"""
         env_patch.stop()
-        shutil.rmtree(td, ignore_errors=os.name=='nt')
+        shutil.rmtree(td, ignore_errors=os.name == 'nt')
 
     request.addfinalizer(fin)
 


### PR DESCRIPTION
better than just checking if it exists, because some on some platforms (e.g. ro AFS on HPC ) os.path.exists() may give False just because os.stat fails, even though the file actually exists

Also adds more test coveraate of the migrated marker checking

Fixes #355