### PR TITLE
Enable async JupyterApp

### DIFF
--- a/jupyter_core/paths.py
+++ b/jupyter_core/paths.py
@@ -174,7 +174,7 @@ def jupyter_data_dir() -> str:
 
     if sys.platform == "darwin":
         return str(Path(home, "Library", "Jupyter"))
-    if sys.platform == "win32":  # type:ignore[unreachable]
+    if sys.platform == "win32":
         appdata = os.environ.get("APPDATA", None)
         if appdata:
             return str(Path(appdata, "jupyter").resolve())

--- a/jupyter_core/paths.py
+++ b/jupyter_core/paths.py
@@ -174,7 +174,7 @@ def jupyter_data_dir() -> str:
 
     if sys.platform == "darwin":
         return str(Path(home, "Library", "Jupyter"))
-    if sys.platform == "win32":
+    if sys.platform == "win32":  # type:ignore[unreachable]
         appdata = os.environ.get("APPDATA", None)
         if appdata:
             return str(Path(appdata, "jupyter").resolve())

--- a/jupyter_core/utils/__init__.py
+++ b/jupyter_core/utils/__init__.py
@@ -158,18 +158,8 @@ def run_sync(coro: Callable[..., Awaitable[T]]) -> Callable[..., T]:
         except RuntimeError:
             pass
 
-        # Run the loop for this thread.
-        # In Python 3.12, a deprecation warning is raised, which
-        # may later turn into a RuntimeError.  We handle both
-        # cases.
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", DeprecationWarning)
-            try:
-                loop = asyncio.get_event_loop()
-            except RuntimeError:
-                loop = asyncio.new_event_loop()
-                asyncio.set_event_loop(loop)
-            return loop.run_until_complete(inner)
+        loop = get_event_loop()
+        return loop.run_until_complete(inner)
 
     wrapped.__doc__ = coro.__doc__
     return wrapped
@@ -194,3 +184,21 @@ async def ensure_async(obj: Awaitable[T] | T) -> T:
         return result
     # obj doesn't need to be awaited
     return cast(T, obj)
+
+
+def get_event_loop() -> asyncio.AbstractEventLoop:
+    # Get the loop for this thread.
+    # In Python 3.12, a deprecation warning is raised, which
+    # may later turn into a RuntimeError.  We handle both
+    # cases.
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        try:
+            loop = asyncio.get_event_loop()
+        except RuntimeError:
+            if sys.platform == "win32":
+                loop = asyncio.WindowsSelectorEventLoopPolicy().new_event_loop()
+            else:
+                loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+    return loop

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -128,14 +128,14 @@ def test_runtime_dir_changed():
 
 
 class AsyncApp(JupyterApp):
-    async def initialize(self, argv):
+    async def initialize_async(self):
         self.value = 10
 
-    async def start(self):
+    async def start_async(self):
         assert self.value == 10
 
 
 def test_async_app():
-    AsyncApp.launch_instance()
+    AsyncApp.launch_instance([])
     app = AsyncApp.instance()
     assert app.value == 10

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -137,3 +137,5 @@ class AsyncApp(JupyterApp):
 
 def test_async_app():
     AsyncApp.launch_instance()
+    app = AsyncApp.instance()
+    assert app.value == 10

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -125,3 +125,15 @@ def test_runtime_dir_changed():
     app.runtime_dir = td
     assert os.path.isdir(td)
     shutil.rmtree(td)
+
+
+class AsyncApp(JupyterApp):
+    async def initialize(self, argv):
+        self.value = 10
+
+    async def start(self):
+        assert self.value == 10
+
+
+def test_async_app():
+    AsyncApp.launch_instance()


### PR DESCRIPTION
- Start an event loop before calling `initialize` and `start` on the app.
- Add `initialize_async` and `start_async` that will be called after their sync versions.
- Expose a `get_event_loop` utility function that gets or sets the event loop for the current thread.

See https://github.com/jupyter/jupyter_client/pull/997 and https://github.com/jupyter-server/jupyter_server/issues/1362 for context.