### PR TITLE
Use supported event loop behavior

### DIFF
--- a/jupyter_core/application.py
+++ b/jupyter_core/application.py
@@ -76,6 +76,9 @@ class JupyterApp(Application):
     aliases = base_aliases
     flags = base_flags
 
+    # Set to True for tornado-based apps.
+    _prefer_selector_loop = False
+
     def _log_level_default(self) -> int:
         return logging.INFO
 
@@ -302,7 +305,7 @@ class JupyterApp(Application):
 
         If a global instance already exists, this reinitializes and starts it
         """
-        loop = get_event_loop()
+        loop = get_event_loop(cls._prefer_selector_loop)
         coro = cls._async_launch_instance(argv, **kwargs)
         loop.run_until_complete(coro)
 

--- a/jupyter_core/utils/__init__.py
+++ b/jupyter_core/utils/__init__.py
@@ -191,7 +191,7 @@ def get_event_loop(prefer_selector_loop: bool = False) -> asyncio.AbstractEventL
     # Get the loop for this thread, or create a new one.
     loop = _thread_data.loop
     if loop and not loop.is_closed():
-        return loop
+        return loop  # type:ignore[no-any-return]
     try:
         loop = asyncio.get_running_loop()
     except RuntimeError:
@@ -201,4 +201,4 @@ def get_event_loop(prefer_selector_loop: bool = False) -> asyncio.AbstractEventL
             loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
     _thread_data.loop = loop
-    return loop
+    return loop  # type:ignore[no-any-return]

--- a/jupyter_core/utils/__init__.py
+++ b/jupyter_core/utils/__init__.py
@@ -192,7 +192,7 @@ def get_event_loop(prefer_selector_loop: bool = False) -> asyncio.AbstractEventL
     # Get the loop for this thread, or create a new one.
     loop = _loop.get()
     if loop is not None and not loop.is_closed():
-        return loop  # type:ignore[no-any-return]
+        return loop
     try:
         loop = asyncio.get_running_loop()
     except RuntimeError:
@@ -202,4 +202,4 @@ def get_event_loop(prefer_selector_loop: bool = False) -> asyncio.AbstractEventL
             loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
     _loop.set(loop)
-    return loop  # type:ignore[no-any-return]
+    return loop

--- a/jupyter_core/utils/__init__.py
+++ b/jupyter_core/utils/__init__.py
@@ -158,7 +158,7 @@ def run_sync(coro: Callable[..., Awaitable[T]]) -> Callable[..., T]:
         except RuntimeError:
             pass
 
-        loop = get_event_loop(allow_stopped=True)
+        loop = get_event_loop()
         return loop.run_until_complete(inner)
 
     wrapped.__doc__ = coro.__doc__
@@ -186,21 +186,14 @@ async def ensure_async(obj: Awaitable[T] | T) -> T:
     return cast(T, obj)
 
 
-def get_event_loop(allow_stopped=False) -> asyncio.AbstractEventLoop:
-    # Get the loop for this thread.
-    # In Python 3.12, a deprecation warning is raised, which
-    # may later turn into a RuntimeError.  We handle both
-    # cases.
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", DeprecationWarning)
-        try:
-            loop = asyncio.get_running_loop()
-        except RuntimeError:
-            if not allow_stopped:
-                raise
-            if sys.platform == "win32":
-                loop = asyncio.WindowsSelectorEventLoopPolicy().new_event_loop()
-            else:
-                loop = asyncio.new_event_loop()
-            asyncio.set_event_loop(loop)
+def get_event_loop() -> asyncio.AbstractEventLoop:
+    # Get the loop for this thread, or create a new one.
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        if sys.platform == "win32":
+            loop = asyncio.WindowsSelectorEventLoopPolicy().new_event_loop()
+        else:
+            loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
     return loop

--- a/jupyter_core/utils/__init__.py
+++ b/jupyter_core/utils/__init__.py
@@ -192,7 +192,7 @@ async def ensure_async(obj: Awaitable[T] | T) -> T:
 def get_event_loop() -> asyncio.AbstractEventLoop:
     # Get the loop for this thread, or create a new one.
     loop = _loop.get()
-    if loop:
+    if loop and not loop.is_closed():
         return loop
     try:
         loop = asyncio.get_running_loop()

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -139,3 +139,13 @@ def test_async_app():
     AsyncApp.launch_instance([])
     app = AsyncApp.instance()
     assert app.value == 10
+
+
+class AsyncTornadoApp(AsyncApp):
+    _prefer_selector_loop = True
+
+
+def test_async_tornado_app():
+    AsyncApp.launch_instance([])
+    app = AsyncApp.instance()
+    assert app.value == 10

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -10,7 +10,13 @@ import tempfile
 
 import pytest
 
-from jupyter_core.utils import deprecation, ensure_async, ensure_dir_exists, run_sync
+from jupyter_core.utils import (
+    deprecation,
+    ensure_async,
+    ensure_dir_exists,
+    get_event_loop,
+    run_sync,
+)
 
 
 def test_ensure_dir_exists():
@@ -42,11 +48,11 @@ def test_run_sync():
     foo_sync = run_sync(foo)
     assert foo_sync() == 1
     assert foo_sync() == 1
-    asyncio.get_event_loop().close()
+    get_event_loop().close()
 
     asyncio.set_event_loop(None)
     assert foo_sync() == 1
-    asyncio.get_event_loop().close()
+    get_event_loop().close()
 
     asyncio.run(foo())
 


### PR DESCRIPTION
Based on discussion in https://github.com/python/cpython/issues/100160, we should not be relying on `asyncio.get_event_loop`, since they are in fact going to make it an alias for `asyncio.get_running_loop`.

As of #381, we are starting the event loop before instantiating our apps, so we should not see any more issues like https://github.com/jupyter/notebook/issues/6721.

Based on results in https://github.com/ipython/ipykernel/pull/1184, we'll want to normally use the default event loop on Windows, unless we know we're running a tornado app.  This PR adds a `prefer_selector_loop` option to `get_event_loop` so we can override `_prefer_selector_loop` in `jupyter_server` apps to prefer the selector loop.