### PR TITLE
Modernize event loop behavior

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -79,7 +79,7 @@ jobs:
         uses: jupyterlab/maintainer-tools/.github/actions/downstream-test@v1
         with:
           package_name: pytest_jupyter
-          package_spec: pip install -e ".[client,server]"
+          package_spec: pip install -e ".[test,client,server]"
 
   downstreams_check: # This job does nothing and is only used for the branch protection
     if: always()

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -66,6 +66,20 @@ jobs:
         with:
           package_name: jupyter_client
 
+  pytest_jupyter:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Base Setup
+        uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+
+      - name: Run Test
+        uses: jupyterlab/maintainer-tools/.github/actions/downstream-test@v1
+        with:
+          package_name: pytest_jupyter
+
   downstreams_check: # This job does nothing and is only used for the branch protection
     if: always()
     needs:
@@ -74,6 +88,7 @@ jobs:
       - nbconvert
       - jupyter_server
       - jupyter_client
+      - pytest_jupyter
     runs-on: ubuntu-latest
     steps:
       - name: Decide whether the needed jobs succeeded or failed

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -79,6 +79,7 @@ jobs:
         uses: jupyterlab/maintainer-tools/.github/actions/downstream-test@v1
         with:
           package_name: pytest_jupyter
+          package_spec: pip install -e ".[client,server]"
 
   downstreams_check: # This job does nothing and is only used for the branch protection
     if: always()

--- a/jupyter_core/application.py
+++ b/jupyter_core/application.py
@@ -29,7 +29,7 @@ from .paths import (
     jupyter_path,
     jupyter_runtime_dir,
 )
-from .utils import ensure_dir_exists, get_event_loop
+from .utils import ensure_dir_exists, ensure_event_loop
 
 # mypy: disable-error-code="no-untyped-call"
 
@@ -278,7 +278,7 @@ class JupyterApp(Application):
     def launch_instance(cls, argv: t.Any = None, **kwargs: t.Any) -> None:
         """Launch an instance of a Jupyter Application"""
         # Ensure an event loop is set before any other code runs.
-        loop = get_event_loop()
+        loop = ensure_event_loop()
         try:
             super().launch_instance(argv=argv, **kwargs)
         except NoStart:
@@ -308,7 +308,7 @@ class JupyterAsyncApp(Application):
     @classmethod
     def launch_instance(cls, argv: t.Any = None, **kwargs: t.Any) -> None:
         """Launch an instance of an async Jupyter Application"""
-        loop = get_event_loop(cls._prefer_selector_loop)
+        loop = ensure_event_loop(cls._prefer_selector_loop)
         coro = cls._launch_instance(argv, **kwargs)
         loop.run_until_complete(coro)
         loop.close()

--- a/jupyter_core/application.py
+++ b/jupyter_core/application.py
@@ -29,7 +29,7 @@ from .paths import (
     jupyter_path,
     jupyter_runtime_dir,
 )
-from .utils import ensure_dir_exists
+from .utils import ensure_dir_exists, get_event_loop
 
 # mypy: disable-error-code="no-untyped-call"
 
@@ -277,10 +277,40 @@ class JupyterApp(Application):
     @classmethod
     def launch_instance(cls, argv: t.Any = None, **kwargs: t.Any) -> None:
         """Launch an instance of a Jupyter Application"""
+        # Ensure an event loop is set before any other code runs.
+        loop = get_event_loop()
         try:
             super().launch_instance(argv=argv, **kwargs)
         except NoStart:
             return
+        loop.close()
+
+
+class JupyterAsyncApp(Application):
+    """A Jupyter application that runs on an asyncio loop."""
+
+    # Set to True for tornado-based apps.
+    _prefer_selector_loop = False
+
+    async def initialize_async(self, argv: t.Any = None) -> None:
+        pass
+
+    async def start_async(self) -> None:
+        pass
+
+    @classmethod
+    async def _launch_instance(cls, argv: t.Any = None, **kwargs: t.Any) -> None:
+        app = cls.instance(**kwargs)
+        app.initialize(argv)
+        await app.initialize_async(argv)
+        await app.start_async()
+
+    @classmethod
+    def launch_instance(cls, argv: t.Any = None, **kwargs: t.Any) -> None:
+        loop = get_event_loop(cls._prefer_selector_loop)
+        coro = cls._launch_instance(argv, **kwargs)
+        loop.run_until_complete(coro)
+        loop.close()
 
 
 if __name__ == "__main__":

--- a/jupyter_core/application.py
+++ b/jupyter_core/application.py
@@ -29,7 +29,7 @@ from .paths import (
     jupyter_path,
     jupyter_runtime_dir,
 )
-from .utils import ensure_dir_exists, get_event_loop
+from .utils import ensure_dir_exists
 
 # mypy: disable-error-code="no-untyped-call"
 
@@ -259,11 +259,6 @@ class JupyterApp(Application):
         self.update_config(cl_config)
         if allow_insecure_writes:
             issue_insecure_write_warning()
-        return
-
-    async def initialize_async(self) -> None:
-        """Perform async initialization of the application, will be called
-        after synchronous initialize."""
 
     def start(self) -> None:
         """Start the whole thing"""
@@ -279,32 +274,13 @@ class JupyterApp(Application):
             self.write_default_config()
             raise NoStart()
 
-        return
-
-    async def start_async(self) -> None:
-        """Perform async start of the app, will be called after sync start."""
-
-    @classmethod
-    async def _async_launch_instance(cls, argv: t.Any = None, **kwargs: t.Any) -> None:
-        """Launch the instance from inside an event loop."""
-        try:
-            app = cls.instance(**kwargs)
-            app.initialize(argv)
-            await app.initialize_async()
-            app.start()
-            await app.start_async()
-        except NoStart:
-            return
-
     @classmethod
     def launch_instance(cls, argv: t.Any = None, **kwargs: t.Any) -> None:
-        """Launch a global instance of this Application
-
-        If a global instance already exists, this reinitializes and starts it
-        """
-        loop = get_event_loop()
-        coro = cls._async_launch_instance(argv, **kwargs)
-        loop.run_until_complete(coro)
+        """Launch an instance of a Jupyter Application"""
+        try:
+            super().launch_instance(argv=argv, **kwargs)
+        except NoStart:
+            return
 
 
 if __name__ == "__main__":

--- a/jupyter_core/application.py
+++ b/jupyter_core/application.py
@@ -293,10 +293,10 @@ class JupyterAsyncApp(Application):
     _prefer_selector_loop = False
 
     async def initialize_async(self, argv: t.Any = None) -> None:
-        pass
+        """Initialize the application asynchronoously."""
 
     async def start_async(self) -> None:
-        pass
+        """Run the application in an event loop."""
 
     @classmethod
     async def _launch_instance(cls, argv: t.Any = None, **kwargs: t.Any) -> None:
@@ -307,6 +307,7 @@ class JupyterAsyncApp(Application):
 
     @classmethod
     def launch_instance(cls, argv: t.Any = None, **kwargs: t.Any) -> None:
+        """Launch an instance of an async Jupyter Application"""
         loop = get_event_loop(cls._prefer_selector_loop)
         coro = cls._launch_instance(argv, **kwargs)
         loop.run_until_complete(coro)

--- a/jupyter_core/utils/__init__.py
+++ b/jupyter_core/utils/__init__.py
@@ -9,6 +9,7 @@ import inspect
 import sys
 import threading
 import warnings
+from contextvars import ContextVar
 from pathlib import Path
 from types import FrameType
 from typing import Any, Awaitable, Callable, TypeVar, cast
@@ -126,6 +127,7 @@ class _TaskRunner:
 
 
 _runner_map: dict[str, _TaskRunner] = {}
+_loop: ContextVar[asyncio.AbstractEventLoop | None] = ContextVar("_loop", default=None)
 
 
 def run_sync(coro: Callable[..., Awaitable[T]]) -> Callable[..., T]:
@@ -159,20 +161,28 @@ def run_sync(coro: Callable[..., Awaitable[T]]) -> Callable[..., T]:
             pass
 
         # Run the loop for this thread.
-        # In Python 3.12, a deprecation warning is raised, which
-        # may later turn into a RuntimeError.  We handle both
-        # cases.
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", DeprecationWarning)
-            try:
-                loop = asyncio.get_event_loop()
-            except RuntimeError:
-                loop = asyncio.new_event_loop()
-                asyncio.set_event_loop(loop)
-            return loop.run_until_complete(inner)
+        loop = get_event_loop()
+        return loop.run_until_complete(inner)
 
     wrapped.__doc__ = coro.__doc__
     return wrapped
+
+
+def get_event_loop(prefer_selector_loop: bool = False) -> asyncio.AbstractEventLoop:
+    # Get the loop for this thread, or create a new one.
+    loop = _loop.get()
+    if loop is not None and not loop.is_closed():
+        return loop
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        if sys.platform == "win32" and prefer_selector_loop:
+            loop = asyncio.WindowsSelectorEventLoopPolicy().new_event_loop()
+        else:
+            loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+    _loop.set(loop)
+    return loop
 
 
 async def ensure_async(obj: Awaitable[T] | T) -> T:

--- a/jupyter_core/utils/__init__.py
+++ b/jupyter_core/utils/__init__.py
@@ -161,14 +161,14 @@ def run_sync(coro: Callable[..., Awaitable[T]]) -> Callable[..., T]:
             pass
 
         # Run the loop for this thread.
-        loop = get_event_loop()
+        loop = ensure_event_loop()
         return loop.run_until_complete(inner)
 
     wrapped.__doc__ = coro.__doc__
     return wrapped
 
 
-def get_event_loop(prefer_selector_loop: bool = False) -> asyncio.AbstractEventLoop:
+def ensure_event_loop(prefer_selector_loop: bool = False) -> asyncio.AbstractEventLoop:
     # Get the loop for this thread, or create a new one.
     loop = _loop.get()
     if loop is not None and not loop.is_closed():

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -10,7 +10,7 @@ import pytest
 from traitlets import Integer
 
 from jupyter_core.application import JupyterApp, JupyterAsyncApp, NoStart
-from jupyter_core.utils import get_event_loop
+from jupyter_core.utils import ensure_event_loop
 
 pjoin = os.path.join
 
@@ -147,7 +147,7 @@ class SyncTornadoApp(JupyterApp):
         self.running_loop = asyncio.get_running_loop()
 
     def start(self):
-        self.starting_loop = get_event_loop()
+        self.starting_loop = ensure_event_loop()
         loop = asyncio.get_event_loop()
         loop.run_until_complete(self._inner())
         loop.close()

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -125,17 +125,3 @@ def test_runtime_dir_changed():
     app.runtime_dir = td
     assert os.path.isdir(td)
     shutil.rmtree(td)
-
-
-class AsyncApp(JupyterApp):
-    async def initialize_async(self):
-        self.value = 10
-
-    async def start_async(self):
-        assert self.value == 10
-
-
-def test_async_app():
-    AsyncApp.launch_instance([])
-    app = AsyncApp.instance()
-    assert app.value == 10

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import os
 import shutil
 from tempfile import mkdtemp
@@ -8,7 +9,8 @@ from unittest.mock import patch
 import pytest
 from traitlets import Integer
 
-from jupyter_core.application import JupyterApp, NoStart
+from jupyter_core.application import JupyterApp, JupyterAsyncApp, NoStart
+from jupyter_core.utils import get_event_loop
 
 pjoin = os.path.join
 
@@ -125,3 +127,60 @@ def test_runtime_dir_changed():
     app.runtime_dir = td
     assert os.path.isdir(td)
     shutil.rmtree(td)
+
+
+class AsyncioRunApp(JupyterApp):
+    async def _inner(self):
+        pass
+
+    def start(self):
+        asyncio.run(self._inner())
+
+
+def test_asyncio_run():
+    AsyncioRunApp.launch_instance([])
+    AsyncioRunApp.clear_instance()
+
+
+class SyncTornadoApp(JupyterApp):
+    async def _inner(self):
+        self.running_loop = asyncio.get_running_loop()
+
+    def start(self):
+        self.starting_loop = get_event_loop()
+        loop = asyncio.get_event_loop()
+        loop.run_until_complete(self._inner())
+        loop.close()
+
+
+def test_sync_tornado_run():
+    SyncTornadoApp.launch_instance([])
+    app = SyncTornadoApp.instance()
+    assert app.running_loop == app.starting_loop
+    SyncTornadoApp.clear_instance()
+
+
+class AsyncApp(JupyterAsyncApp):
+    async def initialize_async(self, argv):
+        self.value = 10
+
+    async def start_async(self):
+        assert self.value == 10
+
+
+def test_async_app():
+    AsyncApp.launch_instance([])
+    app = AsyncApp.instance()
+    assert app.value == 10
+    AsyncApp.clear_instance()
+
+
+class AsyncTornadoApp(AsyncApp):
+    _prefer_selector_loop = True
+
+
+def test_async_tornado_app():
+    AsyncTornadoApp.launch_instance([])
+    app = AsyncApp.instance()
+    assert app._prefer_selector_loop is True
+    AsyncTornadoApp.clear_instance()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -10,7 +10,13 @@ import tempfile
 
 import pytest
 
-from jupyter_core.utils import deprecation, ensure_async, ensure_dir_exists, run_sync
+from jupyter_core.utils import (
+    deprecation,
+    ensure_async,
+    ensure_dir_exists,
+    get_event_loop,
+    run_sync,
+)
 
 
 def test_ensure_dir_exists():
@@ -42,11 +48,11 @@ def test_run_sync():
     foo_sync = run_sync(foo)
     assert foo_sync() == 1
     assert foo_sync() == 1
-    asyncio.get_event_loop().close()
+    get_event_loop().close()
 
     asyncio.set_event_loop(None)
     assert foo_sync() == 1
-    asyncio.get_event_loop().close()
+    get_event_loop().close()
 
     asyncio.run(foo())
 
@@ -57,3 +63,13 @@ def test_ensure_async():
         assert await ensure_async(func()) == "func"
 
     asyncio.run(main())
+
+
+def test_get_event_loop():
+    loop = get_event_loop()
+
+    async def inner():
+        return asyncio.get_running_loop()
+
+    inner_sync = run_sync(inner)
+    assert inner_sync() == loop

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -14,7 +14,7 @@ from jupyter_core.utils import (
     deprecation,
     ensure_async,
     ensure_dir_exists,
-    get_event_loop,
+    ensure_event_loop,
     run_sync,
 )
 
@@ -48,11 +48,11 @@ def test_run_sync():
     foo_sync = run_sync(foo)
     assert foo_sync() == 1
     assert foo_sync() == 1
-    get_event_loop().close()
+    ensure_event_loop().close()
 
     asyncio.set_event_loop(None)
     assert foo_sync() == 1
-    get_event_loop().close()
+    ensure_event_loop().close()
 
     asyncio.run(foo())
 
@@ -65,8 +65,8 @@ def test_ensure_async():
     asyncio.run(main())
 
 
-def test_get_event_loop():
-    loop = get_event_loop()
+def test_ensure_event_loop():
+    loop = ensure_event_loop()
 
     async def inner():
         return asyncio.get_running_loop()


### PR DESCRIPTION
Based on discussion in https://github.com/python/cpython/issues/100160, we should not be relying on `asyncio.get_event_loop`, since they are in fact going to make it an alias for `asyncio.get_running_loop`.

This ensures we install an event loop before launching our apps, so we should not see any more issues like https://github.com/jupyter/notebook/issues/6721.

Additionally, it adds a new class, `JupyterAsyncApp` that runs `initialize_async()` and `start_async()` in an event loop.

Based on results in https://github.com/ipython/ipykernel/pull/1184, we'll want to normally use the default event loop on Windows, unless we know we're running a tornado app.  This PR adds a `prefer_selector_loop` option to `ensure_event_loop` so we can override `_prefer_selector_loop` in `jupyter_server` apps to prefer the selector loop.

Based on failures seen in #383, we add tests to ensure we are not interfering with existing event loop behavior.