### PR TITLE
Use proper assertion.

### DIFF
--- a/jupyter_core/utils/__init__.py
+++ b/jupyter_core/utils/__init__.py
@@ -144,8 +144,7 @@ def run_sync(coro: Callable[..., Awaitable[T]]) -> Callable[..., T]:
         Whatever the coroutine-function returns.
     """
 
-    if not inspect.iscoroutinefunction(coro):
-        raise AssertionError
+    assert inspect.iscoroutinefunction(coro)
 
     def wrapped(*args: Any, **kwargs: Any) -> Any:
         name = threading.current_thread().name


### PR DESCRIPTION
An "AssertionError" message is not that useful, at least here you will see that this is because the object passed in is not a coroutine...