### PR TITLE
MAINT: use new syntax for intersphinx_mapping.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -296,7 +296,7 @@ texinfo_documents = [
 
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {"https://docs.python.org/3/": None}
+intersphinx_mapping = {"python": ("https://docs.python.org/3/", None)}
 
 
 def setup(_):


### PR DESCRIPTION
The old syntax is deprected since sphinx 6.2 and will be removed in teh future.