### PR TITLE
Miscelaneous docs update.

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,4 +9,4 @@ python:
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.11"
+    python: "3.12"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,6 +14,8 @@ from __future__ import annotations
 import shutil
 from pathlib import Path
 
+from intersphinx_registry import get_intersphinx_mapping
+
 from jupyter_core.version import __version__, version_info
 
 # If extensions (or modules to document with autodoc) are in another directory,
@@ -33,7 +35,6 @@ extensions = [
     "myst_parser",
     "sphinx.ext.autodoc",
     "sphinx.ext.intersphinx",
-    "sphinxcontrib_github_alt",
     "sphinx_autodoc_typehints",
 ]
 
@@ -41,7 +42,7 @@ try:
     import enchant  # noqa: F401
 
     extensions += ["sphinxcontrib.spelling"]
-except ImportError:
+except ModuleNotFoundError:
     pass
 
 github_project_url = "https://github.com/jupyter/jupyter_core"
@@ -294,9 +295,7 @@ texinfo_documents = [
 # If true, do not generate a @detailmenu in the "Top" node's menu.
 # texinfo_no_detailmenu = False
 
-
-# Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {"https://docs.python.org/3/": None}
+intersphinx_mapping = get_intersphinx_mapping(packages=["python"])
 
 
 def setup(_):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,12 +47,12 @@ test = [
   "pytest-timeout"
 ]
 docs = [
+  "intersphinx_registry",
   "myst-parser",
-  "sphinxcontrib_github_alt",
-  "sphinxcontrib_spelling",
-  "sphinx-autodoc-typehints",
-  "traitlets",
   "pydata_sphinx_theme",
+  "sphinx-autodoc-typehints",
+  "sphinxcontrib_spelling",
+  "traitlets",
 ]
 
 [project.scripts]


### PR DESCRIPTION
- remove sphinxcontrib_github_alt as it is unused since 5c51ceb6b5516dc330c8311e2b6708fb1f25c5f5
- bump used python in a few places.
- and start using intersphinx_registry to simplify managing intersphinx.