### PR TITLE
Remove option from extension that is not present anymore.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -45,8 +45,6 @@ try:
 except ModuleNotFoundError:
     pass
 
-github_project_url = "https://github.com/jupyter/jupyter_core"
-
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
 


### PR DESCRIPTION
This was used by sphinxcontrib_github_alt, that is not in the list of extensions.