### PR TITLE
AssertionErrors should not be manually raised.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -45,8 +45,6 @@ try:
 except ModuleNotFoundError:
     pass
 
-github_project_url = "https://github.com/jupyter/jupyter_core"
-
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
 

--- a/jupyter_core/utils/__init__.py
+++ b/jupyter_core/utils/__init__.py
@@ -144,8 +144,7 @@ def run_sync(coro: Callable[..., Awaitable[T]]) -> Callable[..., T]:
         Whatever the coroutine-function returns.
     """
 
-    if not inspect.iscoroutinefunction(coro):
-        raise AssertionError
+    assert inspect.iscoroutinefunction(coro)
 
     def wrapped(*args: Any, **kwargs: Any) -> Any:
         name = threading.current_thread().name


### PR DESCRIPTION
assert are meant to be always true – but should be
disabled when running with Python optimisations.

That is to say an optimised run should not raise an assertion error.

This is misusing assertions.

-- 

Also github_project_url is not a sphinx config option anymore.