### PR TITLE
fix package_spec in downstream tests

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -40,7 +40,7 @@ jobs:
       - uses: jupyterlab/maintainer-tools/.github/actions/downstream-test@v1
         with:
           package_name: nbconvert
-          package_spec: pip install -e ".[test]"
+          package_spec: -e ".[test]"
 
   jupyter_server:
     runs-on: ubuntu-latest
@@ -79,4 +79,4 @@ jobs:
         uses: jupyterlab/maintainer-tools/.github/actions/downstream-test@v1
         with:
           package_name: pytest_jupyter
-          package_spec: pip install -e ".[test,client,server]"
+          package_spec: -e ".[test,client,server]"


### PR DESCRIPTION
`pip install` is appended to, not replaced