### PR TITLE
breaking: require Python 3.9

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,10 +28,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.8", "3.12", "3.13"]
+        python-version: ["3.9", "3.12", "3.13"]
         include:
-          - os: windows-latest
-            python-version: "3.9"
           - os: ubuntu-latest
             python-version: "3.11"
           - os: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
   "Programming Language :: Python",
   "Programming Language :: Python :: 3"
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
   "platformdirs>=2.5",
   "traitlets>=5.3",
@@ -102,7 +102,7 @@ build = [
 
 [tool.mypy]
 files = "jupyter_core"
-python_version = "3.8"
+python_version = "3.9"
 strict = true
 enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]
 warn_unreachable = true


### PR DESCRIPTION
maintainer tools doesn't work with Python 3.8 due to problems in hatch, and can't be easily worked around, so drop it.