### PR TITLE
breaking: require Python 3.9

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,10 +28,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.8", "3.12", "3.13"]
+        python-version: ["3.9", "3.12", "3.13"]
         include:
-          - os: windows-latest
-            python-version: "3.9"
           - os: ubuntu-latest
             python-version: "3.11"
           - os: ubuntu-latest

--- a/jupyter_core/paths.py
+++ b/jupyter_core/paths.py
@@ -15,9 +15,10 @@ import stat
 import sys
 import tempfile
 import warnings
+from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, Iterator, Literal, Optional, overload
+from typing import Any, Literal, Optional, overload
 
 import platformdirs
 

--- a/jupyter_core/utils/__init__.py
+++ b/jupyter_core/utils/__init__.py
@@ -9,10 +9,11 @@ import inspect
 import sys
 import threading
 import warnings
+from collections.abc import Awaitable
 from contextvars import ContextVar
 from pathlib import Path
 from types import FrameType
-from typing import Any, Awaitable, Callable, TypeVar, cast
+from typing import Any, Callable, TypeVar, cast
 
 
 def ensure_dir_exists(path: str | Path, mode: int = 0o777) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
   "Programming Language :: Python",
   "Programming Language :: Python :: 3"
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
   "platformdirs>=2.5",
   "traitlets>=5.3",
@@ -102,7 +102,7 @@ build = [
 
 [tool.mypy]
 files = "jupyter_core"
-python_version = "3.8"
+python_version = "3.9"
 strict = true
 enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]
 warn_unreachable = true

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -132,8 +132,9 @@ def test_migrate_one(td):
         called["migrate_dir"] = True
         return migrate_dir(src, dst)
 
-    with patch.object(migrate_mod, "migrate_file", notice_m_file), patch.object(
-        migrate_mod, "migrate_dir", notice_m_dir
+    with (
+        patch.object(migrate_mod, "migrate_file", notice_m_file),
+        patch.object(migrate_mod, "migrate_dir", notice_m_dir),
     ):
         assert migrate_one(src, dst)
         assert called == {"migrate_file": True}


### PR DESCRIPTION
re-issue #426 after 5.8.0 release (last release for Python 3.8)