### PR TITLE
use env config path for system config path when no system config path

### DIFF
--- a/jupyter_core/paths.py
+++ b/jupyter_core/paths.py
@@ -411,7 +411,13 @@ def jupyter_config_path() -> list[str]:
             if userdir not in user:
                 user.append(userdir)
 
-    env = [p for p in ENV_CONFIG_PATH if p not in SYSTEM_CONFIG_PATH]
+    # Windows usually doesn't have a 'system' prefix,
+    # so 'system' and 'env' are the same
+    # make sure that env can still be preferred in this case
+    if ENV_CONFIG_PATH == SYSTEM_CONFIG_PATH:
+        env = ENV_CONFIG_PATH
+    else:
+        env = [p for p in ENV_CONFIG_PATH if p not in SYSTEM_CONFIG_PATH]
 
     if prefer_environment_over_user():
         paths.extend(env)

--- a/jupyter_core/paths.py
+++ b/jupyter_core/paths.py
@@ -338,26 +338,29 @@ def jupyter_path(*subdirs: str) -> list[str]:
     return paths
 
 
+ENV_CONFIG_PATH: list[str] = [str(Path(sys.prefix, "etc", "jupyter"))]
+
 if use_platform_dirs():
     if os.name == "nt" and not _use_programdata:
         # default PROGRAMDATA is not safe by default on Windows
-        SYSTEM_CONFIG_PATH = []
+        # use ENV to avoid an empty list, since some may assume this is non-empty
+        SYSTEM_CONFIG_PATH = ENV_CONFIG_PATH[:]
     else:
         SYSTEM_CONFIG_PATH = platformdirs.site_config_dir(
             APPNAME, appauthor=False, multipath=True
         ).split(os.pathsep)
 elif os.name == "nt":
     # PROGRAMDATA is not defined by default on XP, and not safe by default
+    # but make sure it's not empty
     if _win_programdata:
         SYSTEM_CONFIG_PATH = [str(Path(_win_programdata, "jupyter"))]
     else:
-        SYSTEM_CONFIG_PATH = []
+        SYSTEM_CONFIG_PATH = ENV_CONFIG_PATH[:]
 else:
     SYSTEM_CONFIG_PATH = [
         "/usr/local/etc/jupyter",
         "/etc/jupyter",
     ]
-ENV_CONFIG_PATH: list[str] = [str(Path(sys.prefix, "etc", "jupyter"))]
 
 
 def jupyter_config_path() -> list[str]:

--- a/jupyter_core/paths.py
+++ b/jupyter_core/paths.py
@@ -427,7 +427,8 @@ def jupyter_config_path() -> list[str]:
         paths.extend(env)
 
     # Finally, system path
-    paths.extend(SYSTEM_CONFIG_PATH)
+    if ENV_CONFIG_PATH != SYSTEM_CONFIG_PATH:
+        paths.extend(SYSTEM_CONFIG_PATH)
     return paths
 
 

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -400,6 +400,14 @@ def test_jupyter_config_path_env():
     assert path[:2] == [pjoin("foo", "bar"), pjoin("bar", "baz")]
 
 
+def test_jupyter_config_path_duplicate_sys_env():
+    # make sure we don't repeat duplicate system/env paths
+    with patch("jupyter_core.paths.SYSTEM_CONFIG_PATH", paths.ENV_CONFIG_PATH):
+        config_path = jupyter_config_path()
+    for path in paths.ENV_CONFIG_PATH:
+        assert config_path.count(path) == 1
+
+
 def test_prefer_environment_over_user():
     with prefer_env:
         assert prefer_environment_over_user() is True

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -621,7 +621,7 @@ def test_windows_programdata(request, tmp_path, use_programdata, use_platformdir
         # SIM300 (yoda conditions) gets false positives
         # when the 'variable' we are testing looks like a constant
         if use_programdata in {"0", None}:
-            assert paths.SYSTEM_CONFIG_PATH == []
+            assert paths.SYSTEM_CONFIG_PATH == paths.ENV_CONFIG_PATH
             assert paths.SYSTEM_JUPYTER_PATH == [str(Path(sys.prefix, "share", "jupyter"))]  # noqa:SIM300
         # use_programdata is True
         elif use_platformdirs == "1":


### PR DESCRIPTION
SYSTEM_CONFIG_PATH hasn't technically been guaranteed to be non-empty, but jupyter-server has assumed it is: https://github.com/jupyter-server/jupyter_server/issues/1527 and in practice, it ~always has been until 5.8 because the empty case was weird and rare.

We already use sys.prefix for SYSTEM_JUPYTER_PATH in a similar situation, so it's probably simplest to do the same in config path.

cc @krassowski

I can do a 5.8.1 with this.