### PR TITLE
Convert license settings into PEP-639 format

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,8 @@ build-backend = "hatchling.build"
 [project]
 name = "jupyter_core"
 description = "Jupyter core package. A base package on which Jupyter projects rely."
-license = { file = "LICENSE" }
+license = "BSD-3-Clause"
+license-files = ["LICENSE"]
 classifiers = [
   "Framework :: Jupyter",
   "Intended Audience :: Developers",


### PR DESCRIPTION
The change [here](https://github.com/jupyter/jupyter_core/commit/abc66f1a4418d5aa1f0b7ec56b1e03e135d63a14) led to tools that extract the license (like `pip-licenses`) to fail, because the content of the `LICENSE` file became the license identifier.

This change converts the settings into the PEP-639 format and allows tools to correctly identify the license of installed packages. 

The BSD-3-Clause format is the one suggested [here](https://spdx.org/licenses/BSD-3-Clause.html).