### PR TITLE
fix: handle missing loop case outside except in run_sync

### DIFF
--- a/jupyter_core/utils/__init__.py
+++ b/jupyter_core/utils/__init__.py
@@ -150,9 +150,15 @@ def run_sync(coro: Callable[..., Awaitable[T]]) -> Callable[..., T]:
     def wrapped(*args: Any, **kwargs: Any) -> Any:
         name = threading.current_thread().name
         inner = coro(*args, **kwargs)
+
+        loop_running = False
         try:
             asyncio.get_running_loop()
+            loop_running = True
         except RuntimeError:
+            pass
+
+        if not loop_running:
             # No loop running, run the loop for this thread.
             loop = ensure_event_loop()
             return loop.run_until_complete(inner)


### PR DESCRIPTION
#425 moved the "no running loop" case in `run_sync` to inside the except block, which causes any exceptions thrown by the inner function to have the `RuntimeError` added as "context". That then means that if there is no running event loop, all printed exception tracebacks from the wrapped function have an annoying "RuntimeError: no running event loop" traceback prepended to them.

To reproduce, run this with just `python` directly:
```python
from jupyter_core.utils import run_sync

async def f():
    raise Exception("some exception")

run_sync(f)()

```
It gives
```
Traceback (most recent call last):
  File "/private/tmp/test/.venv/lib/python3.13/site-packages/jupyter_core/utils/__init__.py", line 159, in wrapped
    asyncio.get_running_loop()
    ~~~~~~~~~~~~~~~~~~~~~~~~^^
RuntimeError: no running event loop

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/private/tmp/test/main.py", line 6, in <module>
    run_sync(f)()
    ~~~~~~~~~~~^^
  File "/private/tmp/test/.venv/lib/python3.13/site-packages/jupyter_core/utils/__init__.py", line 163, in wrapped
    return loop.run_until_complete(inner)
           ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^
  File "/opt/homebrew/Cellar/python@3.13/3.13.5/Frameworks/Python.framework/Versions/3.13/lib/python3.13/asyncio/base_events.py", line 725, in run_until_complete
    return future.result()
           ~~~~~~~~~~~~~^^
  File "/private/tmp/test/main.py", line 4, in f
    raise Exception("some exception")
Exception: some exception
```

The actual place I was getting this issue was with `qtconsole` and the in-process `ipykernel`.