### PR TITLE
Fix `filterwarnings()` TypeError

### DIFF
--- a/jupyter_core/utils/__init__.py
+++ b/jupyter_core/utils/__init__.py
@@ -188,7 +188,7 @@ def ensure_event_loop(prefer_selector_loop: bool = False) -> asyncio.AbstractEve
                 with warnings.catch_warnings():
                     warnings.filterwarnings(
                         "ignore",
-                        DeprecationWarning,
+                        category=DeprecationWarning,
                         message=".*WindowsSelectorEventLoopPolicy.*",
                     )
                     loop = asyncio.WindowsSelectorEventLoopPolicy().new_event_loop()


### PR DESCRIPTION
This `filterwarnings()` call is causing `TypeError: filterwarnings() got multiple values for argument 'message'` in downstream package `jupyterlab_server` when testing on Python 3.14 and jupyer_core 5.9 on windows. 