### PR TITLE
Update hatchling version support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling>=1.4"]
+requires = ["hatchling>=1.16"]
 build-backend = "hatchling.build"
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling>=1.16"]
+requires = ["hatchling>=1.26"]
 build-backend = "hatchling.build"
 
 [project]


### PR DESCRIPTION
Older versions of hatchling error out:

```
TypeError: Field `project.license-files` must be a table
```

since https://github.com/jupyter/jupyter_core/commit/2a2807b08381c6a1c84f1624889ccced03f8d93f