### PR TITLE
fix(paths): Correctly resolve Administrator / SYSTEM SID on Windows

### DIFF
--- a/jupyter_core/paths.py
+++ b/jupyter_core/paths.py
@@ -621,9 +621,7 @@ def win32_restrict_file_to_user(fname: str) -> None:
 
     # everyone, _domain, _type = win32security.LookupAccountName("", "Everyone")
     admins = win32security.CreateWellKnownSid(win32security.WinBuiltinAdministratorsSid)
-    user, _domain, _type = win32security.LookupAccountName(
-        "", win32api.GetUserNameEx(win32api.NameSamCompatible)
-    )
+    user, _domain, _type = win32security.LookupAccountName("", win32api.GetUserName())
 
     sd = win32security.GetFileSecurity(fname, win32security.DACL_SECURITY_INFORMATION)
 


### PR DESCRIPTION
See: https://github.com/jupyter/jupyter_client/pull/478

Co-authored-by: @victorsamun

---

Before this change was made, running the following on Windows would cause the following error:

<table><thead><tr><th>PowerShell</th></tr></thead><tbody><tr><td>

```ps1
# Assuming _CONDA_ROOT is already in Env:\
Invoke-Conda update -y -n base -c conda-forge conda
Invoke-Conda create --name jupyter --clone base
Invoke-Conda run -n jupyter conda install conda-forge::jupyter
Invoke-Conda update -y -n jupyter -c conda-forge --update-all
Invoke-Conda run -n jupyter jupyter notebook
```

</td><tr><td>

<details><summary>Error log</summary>

```py
[I 2026-06-01 19:41:17.536 ServerApp] Extension package jupyter_server_terminals took 0.3518s to import
[I 2026-06-01 19:41:17.867 ServerApp] jupyter_lsp | extension was successfully linked.
[I 2026-06-01 19:41:17.877 ServerApp] jupyter_server_terminals | extension was successfully linked.
[I 2026-06-01 19:41:17.899 ServerApp] jupyterlab | extension was successfully linked.
[I 2026-06-01 19:41:17.907 ServerApp] notebook | extension was successfully linked.
[I 2026-06-01 19:41:17.933 ServerApp] Writing Jupyter server cookie secret to C:\Users\Default\.jupyter\data\runtime\jupyter_cookie_secret
[W 2026-06-01 19:41:18.708 ServerApp] notebook_shim | error linking extension: (1332, 'LookupAccountName', 'No mapping between account names and security IDs was done.')
    Traceback (most recent call last):
      File "C:\ProgramData\Conda\envs\jupyter\Lib\site-packages\traitlets\traitlets.py", line 651, in get
        value = obj._trait_values[self.name]
                ~~~~~~~~~~~~~~~~~^^^^^^^^^^^

    KeyError: 'cookie_secret'

    During handling of the above exception, another exception occurred:

    Traceback (most recent call last):
      File "C:\ProgramData\Conda\envs\jupyter\Lib\site-packages\jupyter_server\extension\manager.py", line 388, in link_extension
        extension.link_all_points(self.serverapp)
        ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^
      File "C:\ProgramData\Conda\envs\jupyter\Lib\site-packages\jupyter_server\extension\manager.py", line 265, in link_all_points
        self.link_point(point_name, serverapp)
        ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^
      File "C:\ProgramData\Conda\envs\jupyter\Lib\site-packages\jupyter_server\extension\manager.py", line 250, in link_point
        point.link(serverapp)
        ~~~~~~~~~~^^^^^^^^^^^
      File "C:\ProgramData\Conda\envs\jupyter\Lib\site-packages\jupyter_server\extension\manager.py", line 165, in link
        linker(serverapp)
        ~~~~~~^^^^^^^^^^^
      File "C:\ProgramData\Conda\envs\jupyter\Lib\site-packages\notebook_shim\nbserver.py", line 109, in _link_jupyter_server_extension
        members = diff_members(serverapp, nbapp)
      File "C:\ProgramData\Conda\envs\jupyter\Lib\site-packages\notebook_shim\nbserver.py", line 62, in diff_members
        m1 = public_members(obj1)
      File "C:\ProgramData\Conda\envs\jupyter\Lib\site-packages\notebook_shim\nbserver.py", line 56, in public_members
        members = inspect.getmembers(obj)
      File "C:\ProgramData\Conda\envs\jupyter\Lib\inspect.py", line 628, in getmembers
        return _getmembers(object, predicate, getattr)
      File "C:\ProgramData\Conda\envs\jupyter\Lib\inspect.py", line 606, in _getmembers
        value = getter(object, key)
      File "C:\ProgramData\Conda\envs\jupyter\Lib\site-packages\traitlets\traitlets.py", line 706, in __get__
        return self.get(obj, cls)  # type:ignore[return-value]
               ~~~~~~~~^^^^^^^^^^
      File "C:\ProgramData\Conda\envs\jupyter\Lib\site-packages\traitlets\traitlets.py", line 654, in get
        default = obj.trait_defaults(self.name)
      File "C:\ProgramData\Conda\envs\jupyter\Lib\site-packages\traitlets\traitlets.py", line 1905, in trait_defaults
        return self._get_trait_default_generator(names[0])(self)  # type:ignore[no-any-return]
               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^
      File "C:\ProgramData\Conda\envs\jupyter\Lib\site-packages\traitlets\traitlets.py", line 1260, in __call__
        return self.func(*args, **kwargs)
               ~~~~~~~~~^^^^^^^^^^^^^^^^^
      File "C:\ProgramData\Conda\envs\jupyter\Lib\site-packages\jupyter_server\serverapp.py", line 1167, in _default_cookie_secret
        self._write_cookie_secret_file(key)
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^
      File "C:\ProgramData\Conda\envs\jupyter\Lib\site-packages\jupyter_server\serverapp.py", line 1177, in _write_cookie_secret_file
        with secure_write(self.cookie_secret_file, True) as f:
             ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "C:\ProgramData\Conda\envs\jupyter\Lib\contextlib.py", line 141, in __enter__
        return next(self.gen)
      File "C:\ProgramData\Conda\envs\jupyter\Lib\site-packages\jupyter_core\paths.py", line 1080, in secure_write
        win32_restrict_file_to_user(fname)
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^
      File "C:\ProgramData\Conda\envs\jupyter\Lib\site-packages\jupyter_core\paths.py", line 624, in win32_restrict_file_to_user
        user, _domain, _type = win32security.LookupAccountName(
                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
            "", win32api.GetUserNameEx(win32api.NameSamCompatible)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        )
        ^
    pywintypes.error: (1332, 'LookupAccountName', 'No mapping between account names and security IDs was done.')
[I 2026-06-01 19:41:18.857 ServerApp] notebook_shim | extension was successfully loaded.
[I 2026-06-01 19:41:18.868 ServerApp] jupyter_lsp | extension was successfully loaded.
[I 2026-06-01 19:41:18.873 ServerApp] jupyter_server_terminals | extension was successfully loaded.
[I 2026-06-01 19:41:18.891 LabApp] JupyterLab extension loaded from C:\ProgramData\Conda\envs\jupyter\Lib\site-packages\jupyterlab
[I 2026-06-01 19:41:18.892 LabApp] JupyterLab application directory is C:\ProgramData\Conda\envs\jupyter\share\jupyter\lab
[I 2026-06-01 19:41:18.893 LabApp] Extension Manager is 'pypi'.
[I 2026-06-01 19:41:19.056 ServerApp] jupyterlab | extension was successfully loaded.
[I 2026-06-01 19:41:19.075 ServerApp] notebook | extension was successfully loaded.
[I 2026-06-01 19:41:19.078 ServerApp] Serving notebooks from local directory: C:\temp
[I 2026-06-01 19:41:19.079 ServerApp] Jupyter Server 2.19.0 is running at:
[I 2026-06-01 19:41:19.079 ServerApp] http://localhost:8888/tree?token=7ff8f99adb638bf7713ba60b6fe6b6e5be1c7b605964c3de
[I 2026-06-01 19:41:19.079 ServerApp] http://127.0.0.1:8888/tree?token=7ff8f99adb638bf7713ba60b6fe6b6e5be1c7b605964c3de
[I 2026-06-01 19:41:19.080 ServerApp] Use Control-C to stop this server and shut down all kernels (twice to skip confirmation).
Traceback (most recent call last):
  File "C:\ProgramData\Conda\envs\jupyter\Scripts\jupyter-notebook-script.py", line 9, in <module>
    sys.exit(main())
             ~~~~^^
  File "C:\ProgramData\Conda\envs\jupyter\Lib\site-packages\jupyter_server\extension\application.py", line 635, in launch_instance
    serverapp.start()
    ~~~~~~~~~~~~~~~^^
  File "C:\ProgramData\Conda\envs\jupyter\Lib\site-packages\jupyter_server\serverapp.py", line 3220, in start
    self.start_app()
    ~~~~~~~~~~~~~~^^
  File "C:\ProgramData\Conda\envs\jupyter\Lib\site-packages\jupyter_server\serverapp.py", line 3109, in start_app
    self.write_server_info_file()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "C:\ProgramData\Conda\envs\jupyter\Lib\site-packages\jupyter_server\serverapp.py", line 2915, in write_server_info_file
    with secure_write(self.info_file) as f:
         ~~~~~~~~~~~~^^^^^^^^^^^^^^^^
  File "C:\ProgramData\Conda\envs\jupyter\Lib\contextlib.py", line 141, in __enter__
    return next(self.gen)
  File "C:\ProgramData\Conda\envs\jupyter\Lib\site-packages\jupyter_core\paths.py", line 1080, in secure_write
    win32_restrict_file_to_user(fname)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^
  File "C:\ProgramData\Conda\envs\jupyter\Lib\site-packages\jupyter_core\paths.py", line 624, in win32_restrict_file_to_user
    user, _domain, _type = win32security.LookupAccountName(
                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        "", win32api.GetUserNameEx(win32api.NameSamCompatible)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
pywintypes.error: (1332, 'LookupAccountName', 'No mapping between account names and security IDs was done.')
ERROR conda.cli.main_run:execute(148): `conda run jupyter notebook` failed. (See above for error)
```

</details></td></tr></tr><tr><td>

Proof that this resolves the issue:

<img src="https://github.com/user-attachments/assets/244c1d48-4e6d-46c0-9cea-f94948e0ccc1" alt="Proof that this works as intended" width="100%" style="width: 100%; width: -moz-available; width: -webkit-fill-available; width: fill-available;"/>

</td></tr></tbody></table>
