### PR TITLE
Add /opt/homebrew to SYSTEM paths on Apple Silicon Homebrew

### DIFF
--- a/jupyter_core/paths.py
+++ b/jupyter_core/paths.py
@@ -25,9 +25,8 @@ import platformdirs
 pjoin = os.path.join
 
 # Capitalize Jupyter in paths only on Windows and MacOS (when not in Homebrew)
-if sys.platform == "win32" or (
-    sys.platform == "darwin" and not sys.prefix.startswith("/opt/homebrew")
-):
+_is_apple_silicon_homebrew = sys.platform == "darwin" and sys.prefix.startswith("/opt/homebrew")
+if sys.platform == "win32" or (sys.platform == "darwin" and not _is_apple_silicon_homebrew):
     APPNAME = "Jupyter"
 else:
     APPNAME = "jupyter"
@@ -239,6 +238,9 @@ else:  # noqa: PLR5501
             "/usr/local/share/jupyter",
             "/usr/share/jupyter",
         ]
+        # Apple Silicon Homebrew uses /opt/homebrew.
+        if _is_apple_silicon_homebrew:
+            SYSTEM_JUPYTER_PATH.insert(0, "/opt/homebrew/share/jupyter")
 
 ENV_JUPYTER_PATH: list[str] = [str(Path(sys.prefix, "share", "jupyter"))]
 
@@ -354,6 +356,8 @@ else:
         "/usr/local/etc/jupyter",
         "/etc/jupyter",
     ]
+    if _is_apple_silicon_homebrew:
+        SYSTEM_CONFIG_PATH.insert(0, "/opt/homebrew/etc/jupyter")
 
 
 def jupyter_config_path() -> list[str]:

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -625,6 +625,34 @@ def test_insecure_write_warning():
         issue_insecure_write_warning()
 
 
+@pytest.mark.parametrize(
+    ("prefix", "expect_homebrew"),
+    [
+        ("/opt/homebrew/opt/python@3.13/Frameworks/Python.framework/Versions/3.13", True),
+        (
+            "/opt/homebrew/Cellar/python@3.13/3.13.0_1/Frameworks/Python.framework/Versions/3.13",
+            True,
+        ),
+        ("/Library/Frameworks/Python.framework/Versions/3.13", False),
+        ("/usr/local/opt/python@3.13/Frameworks/Python.framework/Versions/3.13", False),
+    ],
+)
+def test_apple_silicon_homebrew_system_paths(request, prefix, expect_homebrew):
+    """Verify SYSTEM_*_PATH includes /opt/homebrew on Apple Silicon Homebrew Python.
+
+    See https://github.com/jupyter/jupyter_core/issues/250.
+    """
+    request.addfinalizer(lambda: reload(paths))
+    with patch.object(sys, "platform", "darwin"), patch.object(sys, "prefix", prefix):
+        reload(paths)
+        if expect_homebrew:
+            assert "/opt/homebrew/share/jupyter" in paths.SYSTEM_JUPYTER_PATH
+            assert "/opt/homebrew/etc/jupyter" in paths.SYSTEM_CONFIG_PATH
+        else:
+            assert "/opt/homebrew/share/jupyter" not in paths.SYSTEM_JUPYTER_PATH
+            assert "/opt/homebrew/etc/jupyter" not in paths.SYSTEM_CONFIG_PATH
+
+
 @windows
 @pytest.mark.parametrize("use_programdata", ["1", "0", None])
 @pytest.mark.parametrize("use_platformdirs", ["1", "0"])


### PR DESCRIPTION
Closes #250.

On Apple Silicon Homebrew, `sys.prefix` is the Cellar path, but pip installs share-data to `/opt/homebrew/share/jupyter`, which isn't in `SYSTEM_JUPYTER_PATH`. So `jupyter labextension list` is empty, server extensions don't load, `/lab` 500s.

Adds `/opt/homebrew/{share,etc}/jupyter` to the system paths, gated on the same `sys.prefix.startswith("/opt/homebrew")` check from #364.

Intel Homebrew is at `/usr/local`, already in the list, so unaffected — the split is because Homebrew picked `/opt/homebrew` for arm64 to coexist with Rosetta installs at `/usr/local` (https://docs.brew.sh/FAQ#why-is-the-default-installation-prefix-opthomebrew-on-apple-silicon). Linuxbrew has the same shape but out of scope.

Pre-existing 3 `_darwin` test failures handled in #458.